### PR TITLE
feature: AuthGuard,improve: i18n

### DIFF
--- a/src/api/auth/auth.controller.ts
+++ b/src/api/auth/auth.controller.ts
@@ -4,20 +4,22 @@ import { AuthService } from './auth.service';
 import { CreateUserDto } from 'src/validation/class_validation/user.validation';
 import { I18nService } from 'nestjs-i18n';
 import { Language } from 'src/helper/decorators/language.decorator';
+import { Public } from 'src/helper/decorators/metadata.decorator';
 
 @Controller('auth')
 export class AuthController {
     constructor(
         private readonly authService: AuthService,
-        private readonly i18nService: I18nService
     ) { }
 
+    @Public()
     @Post('login')
     async login(@Body() userInput: AuthDto, @Language() lang: string) {
         const result = await this.authService.login(userInput,lang);
         return result;
     }
 
+    @Public()
     @Post('register')
     async register(@Body() userInput: CreateUserDto, @Language() lang: string) {
         const result = await this.authService.register(userInput,lang);

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -15,7 +15,7 @@ import { UserSubject } from './database/entities/user_subject.entity';
 import { UserTask } from './database/entities/user_task.entity';
 import { SnakeNamingStrategy } from 'typeorm-naming-strategies';
 import { ApiModule } from './api/api.module';
-import { APP_FILTER, APP_INTERCEPTOR } from '@nestjs/core';
+import { APP_FILTER, APP_GUARD, APP_INTERCEPTOR } from '@nestjs/core';
 import { AllExceptionFilter } from './helper/exceptions_filter/http_exception.helper';
 import { TransfromResponse } from './helper/Interceptors/transfrom.interceptor';
 import { 
@@ -30,6 +30,7 @@ import { I18nUtils } from './helper/utils/i18n-utils';
 import * as path from 'path';
 
 import * as dotenv from 'dotenv';
+import { AuthGuard } from './middleware/guard.middleware';
 dotenv.config();
 
 @Module({
@@ -64,7 +65,7 @@ dotenv.config();
           entities: [User, Course, Subject, Task, CourseSubject, SupervisorCourse, UserCourse, UserSubject, UserTask],
           namingStrategy: new SnakeNamingStrategy(),
           synchronize: false,
-          logging: true,
+          logging: false,
         };
       },
       inject: [ConfigService],
@@ -83,6 +84,10 @@ dotenv.config();
       provide: APP_INTERCEPTOR,
       useClass: TransfromResponse,
     },
+    {
+      provide: APP_GUARD,
+      useClass: AuthGuard
+    }
   ],
   exports: [I18nUtils],
 })

--- a/src/helper/constants/lang.constant.ts
+++ b/src/helper/constants/lang.constant.ts
@@ -1,0 +1,13 @@
+import { Injectable } from "@nestjs/common";
+import { asyncLocalStorage } from "src/middleware/language.middleware";
+
+export const langConstant = {
+    VN: 'vn',
+    EN: 'en'
+}
+
+export const LanguageRequest = () => {
+    const store = asyncLocalStorage.getStore();
+    const lang = store?.get('lang') || langConstant.VN;
+    return lang;
+}

--- a/src/helper/decorators/i18n-validation.decorator.ts
+++ b/src/helper/decorators/i18n-validation.decorator.ts
@@ -1,7 +1,4 @@
-import {
-  ValidationOptions,
-  ValidationArguments,
-} from 'class-validator';
+import { ValidationOptions, ValidationArguments } from 'class-validator';
 import { I18nService } from 'nestjs-i18n';
 
 let i18nService: I18nService;
@@ -10,11 +7,16 @@ export function setI18nService(service: I18nService) {
   i18nService = service;
 }
 
-function getI18nMessage(key: string, args: any[] = []): string {
+function getI18nMessageSync(key: string, args: Record<string, any> = {}): string {
   if (!i18nService) {
     return `I18nService not available. Key: ${key}`;
   }
-  return i18nService.translate(key, { args });
+
+  const translation = (i18nService as any).translateSync
+    ? (i18nService as any).translateSync(key, { args })
+    : key;
+
+  return translation;
 }
 
 export function i18nValidationMessage(
@@ -24,8 +26,8 @@ export function i18nValidationMessage(
   return {
     ...validationOptions,
     message: (args: ValidationArguments) => {
-      const argsArray = Object.values(args.constraints || []);
-      return getI18nMessage(key, argsArray);
+      const constraints = args.constraints?.[0] || {};
+      return getI18nMessageSync(key, constraints);
     },
   };
-} 
+}

--- a/src/helper/decorators/language.decorator.ts
+++ b/src/helper/decorators/language.decorator.ts
@@ -3,12 +3,12 @@ import { createParamDecorator, ExecutionContext } from '@nestjs/common';
 export const Language = createParamDecorator(
   (data: string, ctx: ExecutionContext) => {
     const request = ctx.switchToHttp().getRequest();
-    
-    const lang = 
-      request.query?.lang || 
-      request.headers['accept-language'] || 
+
+    const lang =
+      request.query?.lang ||
+      request.headers['accept-language'] ||
       request.cookies?.lang;
-    
-    return lang || 'vi';
+
+    return lang;
   },
 ); 

--- a/src/helper/decorators/metadata.decorator.ts
+++ b/src/helper/decorators/metadata.decorator.ts
@@ -1,0 +1,4 @@
+import { SetMetadata } from "@nestjs/common"
+
+export const IS_PUBLIC_KEY = 'isPublic'
+export const Public = () => SetMetadata(IS_PUBLIC_KEY,true);

--- a/src/helper/exceptions_filter/http_exception.helper.ts
+++ b/src/helper/exceptions_filter/http_exception.helper.ts
@@ -1,42 +1,47 @@
-import { ArgumentsHost, Catch, ExceptionFilter, HttpException } from "@nestjs/common";
+import { ArgumentsHost, Catch, ExceptionFilter, HttpException, Inject } from "@nestjs/common";
 import { StatusCodes } from "../constants/status_code.constant";
+import { langConstant, LanguageRequest } from "../constants/lang.constant";
+import { I18nUtils } from "../utils/i18n-utils";
+import { asyncLocalStorage } from "src/middleware/language.middleware";
 
 @Catch(HttpException)
 export class AllExceptionFilter implements ExceptionFilter {
-    catch(exception: any, host: ArgumentsHost) {
-        const ctx = host.switchToHttp();
-        const request = ctx.getRequest();
-        const response = ctx.getResponse();
+  constructor(private readonly i18n: I18nUtils) { }
 
-        const status =
-            exception instanceof HttpException
-                ? exception.getStatus()
-                : StatusCodes.ERROR;
+  async catch(exception: any, host: ArgumentsHost) {
+    const ctx = host.switchToHttp();
+    const request = ctx.getRequest();
+    const response = ctx.getResponse();
+    const lang = LanguageRequest()
+    
+    const status = exception instanceof HttpException
+      ? exception.getStatus()
+      : StatusCodes.ERROR;
 
-        const responseData =
-            exception instanceof HttpException
-                ? exception.getResponse()
-                : 'Internal server error';
+    const responseData = exception instanceof HttpException
+      ? exception.getResponse()
+      : this.i18n.translate('server.internal_server_error', {}, lang);
 
-        let errorMessage: string;
+    let errorMessage: string;
 
-        if (typeof responseData === 'string') {
-            errorMessage = responseData;
-        } else if (typeof responseData === 'object' && responseData !== null) {
-            errorMessage =
-                (responseData as any).message ||
-                (responseData as any).error ||
-                'Internal server error';
-        } else {
-            errorMessage = 'Internal server error';
-        }
-
-        response.status(status).json({
-            success: false,
-            code: status,
-            message: errorMessage,
-            timestamp: new Date().toISOString(),
-            path: request.url,
-        });
+    if (typeof responseData === 'string') {
+      errorMessage = responseData;
+    } else if (typeof responseData === 'object' && responseData !== null) {
+      const rawMessage =
+        (responseData as any).message ||
+        (responseData as any).error ||
+        'server.internal_server_error';
+      errorMessage = this.i18n.translate(rawMessage, {}, lang);
+    } else {
+      errorMessage = this.i18n.translate('server.internal_server_error', {}, lang);
     }
+
+    response.status(status).json({
+      success: false,
+      code: status,
+      message: errorMessage,
+      timestamp: new Date().toISOString(),
+      path: request.url,
+    });
+  }
 }

--- a/src/helper/types/express.type.ts
+++ b/src/helper/types/express.type.ts
@@ -1,0 +1,7 @@
+import { payLoadDataType } from '../interface/pay_load.interface';
+
+declare module 'express' {
+  interface Request {
+    user?: payLoadDataType;
+  }
+}

--- a/src/helper/utils/i18n-utils.ts
+++ b/src/helper/utils/i18n-utils.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { I18nService } from 'nestjs-i18n';
+import { langConstant } from '../constants/lang.constant';
 
 @Injectable()
 export class I18nUtils {
@@ -7,7 +8,7 @@ export class I18nUtils {
 
   translate(key: string, args: any = {}, lang?: string): string {
     return this.i18nService.translate(key, {
-      lang: lang || 'vi',
+      lang: lang || langConstant.VN,
       args,
     });
   }

--- a/src/i18n/en/validation.json
+++ b/src/i18n/en/validation.json
@@ -24,7 +24,14 @@
     "invalid_credentials": "Invalid email or password",
     "login_success": "Login successful",
     "register_success": "Registration successful",
-    "email_exists": "Email already exists"
+    "email_exists": "Email already exists",
+    "token_missing": "Token is not provided",
+    "token_invalid": "Token is invalid",
+    "token_expired": "Token has expired",
+    "access_denied": "You do not have permission to access this resource"
+  },
+  "server": {
+    "internal_server_error": "Internal server error"
   },
   "course": {
     "name": {
@@ -159,4 +166,4 @@
       "isNotEmpty": "Status cannot be empty"
     }
   }
-} 
+}

--- a/src/i18n/vi/validation.json
+++ b/src/i18n/vi/validation.json
@@ -24,7 +24,14 @@
     "invalid_credentials": "Email hoặc mật khẩu không đúng",
     "login_success": "Đăng nhập thành công",
     "register_success": "Đăng ký thành công",
-    "email_exists": "Email đã tồn tại"
+    "email_exists": "Email đã tồn tại",
+    "token_missing": "Token không được cung cấp",
+    "token_invalid": "Token không hợp lệ",
+    "token_expired": "Token đã hết hạn",
+    "access_denied": "Bạn không đủ quyền truy cập"
+  },
+  "server": {
+    "internal_server_error": "Lỗi máy chủ nội bộ"
   },
   "course": {
     "name": {
@@ -159,4 +166,4 @@
       "isNotEmpty": "Trạng thái không được để trống"
     }
   }
-} 
+}

--- a/src/middleware/guard.middleware.ts
+++ b/src/middleware/guard.middleware.ts
@@ -1,0 +1,54 @@
+import { CanActivate, ExecutionContext, Inject, Injectable, Request, UnauthorizedException } from "@nestjs/common";
+import { Reflector } from "@nestjs/core";
+import { JwtService } from "@nestjs/jwt";
+import { JWT_SECRET } from "src/helper/constants/jwt_token.constant";
+import { LanguageRequest } from "src/helper/constants/lang.constant";
+import { IS_PUBLIC_KEY } from "src/helper/decorators/metadata.decorator";
+import { I18nUtils } from "src/helper/utils/i18n-utils";
+
+@Injectable()
+export class AuthGuard implements CanActivate {
+    constructor(
+        private readonly reflector: Reflector,
+        private readonly jwtToken: JwtService,
+        private readonly I18nUtils: I18nUtils
+    ) { }
+
+    async canActivate(context: ExecutionContext): Promise<boolean> {
+        const isPublic = this.reflector.getAllAndOverride<boolean>(IS_PUBLIC_KEY, [
+            context.getHandler(),
+            context.getClass(),
+        ]);
+
+        if (isPublic) return true;
+
+        const request = context.switchToHttp().getRequest();
+        const token = this.checkTokenFromHeader(request);
+        const lang = LanguageRequest();
+
+        if (!token) {
+            throw new UnauthorizedException(this.I18nUtils.translate('validation.auth.token_missing', {}, lang));
+        }
+
+        try {
+            const payLoad = await this.jwtToken.verifyAsync(token, { secret: JWT_SECRET });
+            request.user = payLoad;
+        } catch {
+            throw new UnauthorizedException(this.I18nUtils.translate('validation.auth.token_invalid', {}, lang));
+        }
+
+        return true
+    }
+
+    private checkTokenFromHeader(request: Request): string | undefined {
+        const authHeader = request.headers['authorization'];
+
+        if (!authHeader || typeof authHeader !== 'string' || !authHeader.startsWith('Bearer ')) {
+            return undefined;
+        }
+
+        const token = authHeader.split(' ')[1];
+        return token
+    }
+}
+

--- a/src/middleware/language.middleware.ts
+++ b/src/middleware/language.middleware.ts
@@ -1,20 +1,17 @@
 import { Injectable, NestMiddleware } from '@nestjs/common';
 import { Request, Response, NextFunction } from 'express';
 import { I18nService } from 'nestjs-i18n';
+import { AsyncLocalStorage } from 'async_hooks';
+
+export const asyncLocalStorage = new AsyncLocalStorage<Map<string, any>>();
 
 @Injectable()
 export class LanguageMiddleware implements NestMiddleware {
-  constructor(private readonly i18n: I18nService) {}
+  use(req: any, res: any, next: () => void) {
+    const lang = req.query.lang || req.headers['accept-language'] || req.cookies?.lang || 'vi';
 
-  use(req: Request, res: Response, next: NextFunction) {
-    const lang = 
-      req.query.lang as string || 
-      req.headers['accept-language'] || 
-      req.cookies?.lang ||
-      'vi';
-    
-    req['lang'] = lang;
-    
-    next();
+    asyncLocalStorage.run(new Map([['lang', lang]]), () => {
+      next();
+    });
   }
-} 
+}

--- a/src/validation/auth_validation/auth.validation.ts
+++ b/src/validation/auth_validation/auth.validation.ts
@@ -1,4 +1,4 @@
-import { IsString, IsEmail, IsNotEmpty, MinLength} from 'class-validator';
+import { IsString, IsEmail, IsNotEmpty, MinLength } from 'class-validator';
 import { i18nValidationMessage } from '../../helper/decorators/i18n-validation.decorator';
 
 export class AuthDto {

--- a/src/validation/class_validation/user.validation.ts
+++ b/src/validation/class_validation/user.validation.ts
@@ -1,6 +1,7 @@
 import { IsEmail, IsEnum, IsNotEmpty, IsOptional, IsString, MinLength, MaxLength, } from 'class-validator';
 import { Role, UserStatus } from '../../database/dto/user.dto';
 import { i18nValidationMessage } from '../../helper/decorators/i18n-validation.decorator';
+import { IsStrongPassword } from 'src/helper/decorators/i18n-validators';
 
 export class CreateUserDto {
     @IsEmail({}, i18nValidationMessage('validation.email.isEmail'))
@@ -15,6 +16,7 @@ export class CreateUserDto {
     @IsString(i18nValidationMessage('validation.password.isString'))
     @IsNotEmpty(i18nValidationMessage('validation.password.isNotEmpty'))
     @MinLength(6, i18nValidationMessage('validation.password.minLength'))
+    @IsStrongPassword()
     password: string;
 }
 
@@ -31,6 +33,7 @@ export class UpdateUserDto {
     @IsString(i18nValidationMessage('validation.password.isString'))
     @IsOptional()
     @MinLength(6, i18nValidationMessage('validation.password.minLength'))
+    @IsStrongPassword()
     password?: string;
 
     @IsEnum(Role, i18nValidationMessage('validation.role.isEnum'))

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,6 +16,7 @@
     "forceConsistentCasingInFileNames": true,
     "noImplicitAny": false,
     "strictBindCallApply": false,
-    "noFallthroughCasesInSwitch": false
+    "noFallthroughCasesInSwitch": false,
+    "typeRoots": ["./node_modules/@types", "./src/helper/types"]
   }
 }


### PR DESCRIPTION
- **Cải tiến i18n**:
 + **Middleware Ngôn ngữ Thông minh hơn**: Sử dụng AsyncLocalStorage để lưu trữ ngôn ngữ của người dùng trong suốt vòng đời của một request.
+ **Dịch Validation Messages Đồng bộ**: Cập nhật decorator i18nValidationMessage để sử dụng translateSync cho việc dịch các thông báo lỗi validation.
+ Xử lý Ngoại lệ Đa ngôn ngữ: AllExceptionFilter giờ đây đã được tích hợp với i18n, cho phép trả về các thông báo lỗi HTTP được dịch sang ngôn ngữ của người dùng, cải thiện trải nghiệm người dùng.
- **Chức năng AuthGuard**:
 + **Global AuthGuard**: Đã thêm một AuthGuard global để bảo vệ tất cả các endpoint của ứng dụng. Guard này sẽ tự động xác thực token JWT từ header Authorization.
 + **Tích hợp i18n trong AuthGuard**: AuthGuard sử dụng hệ thống i18n để trả về các thông báo lỗi xác thực (ví dụ: "token không hợp lệ", "token bị thiếu") bằng ngôn ngữ của người dùng, giúp cung cấp phản hồi rõ ràng và thân thiện hơn.
 + **Endpoint Công khai**: AuthGuard cho phép các endpoint được đánh dấu là công khai (public) bằng cách sử dụng decorator IS_PUBLIC_KEY, cho phép bỏ qua quá trình xác thực khi cần thiết.