### PR TITLE
Feature: start_course

### DIFF
--- a/src/api/course/course.controller.ts
+++ b/src/api/course/course.controller.ts
@@ -66,18 +66,25 @@ export class CourseController {
         return result;
     }
 
-    @AuthRoles(Role.ADMIN,Role.SUPERVISOR)
+    @AuthRoles(Role.ADMIN, Role.SUPERVISOR)
     @Post(':courseId/trainee')
-    async assignTraineeToCourse (@Param() courseId: courseIdDto, @Body() traineeId:userIdDto, @Language() lang:string) {
-        const result = await this.courseService.assignTraineeToCourse(courseId.courseId,traineeId.userId,lang);
+    async assignTraineeToCourse(@Param() courseId: courseIdDto, @Body() traineeId: userIdDto, @Language() lang: string) {
+        const result = await this.courseService.assignTraineeToCourse(courseId.courseId, traineeId.userId, lang);
         return result;
     }
 
-    @AuthRoles(Role.ADMIN,Role.SUPERVISOR)
+    @AuthRoles(Role.ADMIN, Role.SUPERVISOR)
     @Delete(':courseId/trainee/:traineeId')
-    async removeTraineeFromCourse (@Param() param: { courseId: number; traineeId: number},@Language() lang:string) {
+    async removeTraineeFromCourse(@Param() param: { courseId: number; traineeId: number }, @Language() lang: string) {
         const { courseId, traineeId } = param;
-        const result = await this.courseService.removeTraineeFromCourse(courseId,traineeId,lang)
+        const result = await this.courseService.removeTraineeFromCourse(courseId, traineeId, lang)
+        return result;
+    }
+
+    @AuthRoles(Role.ADMIN, Role.SUPERVISOR)
+    @Post(':courseId/start')
+    async startCourse(@Param() courseId: courseIdDto, @Language() lang: string) {
+        const result = await this.courseService.startCourse(courseId.courseId, lang);
         return result;
     }
 }

--- a/src/api/course/course.module.ts
+++ b/src/api/course/course.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { Logger, Module } from '@nestjs/common';
 import { CourseController } from './course.controller';
 import { CourseService } from './course.service';
 import { I18nUtils } from 'src/helper/utils/i18n-utils';
@@ -11,10 +11,11 @@ import { SupervisorCourse } from 'src/database/entities/supervisor_course.entity
 import { PaginationService } from 'src/helper/shared/pagination.shared';
 import { User } from 'src/database/entities/user.entity';
 import { GetCourse } from 'src/helper/shared/get_course.shared';
+import { UserSubject } from 'src/database/entities/user_subject.entity';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Course,UserCourse,CourseSubject,SupervisorCourse,User])],
+  imports: [TypeOrmModule.forFeature([Course,UserCourse,CourseSubject,SupervisorCourse,User,UserSubject])],
   controllers: [CourseController],
-  providers: [CourseService,I18nUtils,hashPassword,PaginationService,GetCourse]
+  providers: [CourseService,I18nUtils,hashPassword,PaginationService,GetCourse,Logger]
 })
 export class SourseModule {}

--- a/src/api/course/course.service.ts
+++ b/src/api/course/course.service.ts
@@ -7,12 +7,14 @@ import { CourseStatus } from 'src/database/dto/course.dto';
 import { CourseSubjectStatus } from 'src/database/dto/course_subject.dto';
 import { Role } from 'src/database/dto/user.dto';
 import { UserCourseStatus } from 'src/database/dto/user_course.dto';
+import { UserSubjectStatus } from 'src/database/dto/user_subject.dto';
 import { Course } from 'src/database/entities/course.entity';
 import { CourseSubject } from 'src/database/entities/course_subject.entity';
 import { SupervisorCourse } from 'src/database/entities/supervisor_course.entity';
 import { User } from 'src/database/entities/user.entity';
 import { UserCourse } from 'src/database/entities/user_course.entity';
-import { firstCourseProgress, todayDate } from 'src/helper/constants/cron_expression.constant';
+import { UserSubject } from 'src/database/entities/user_subject.entity';
+import { firstCourseProgress, firstUserSubjectProgress, todayDate } from 'src/helper/constants/cron_expression.constant';
 import { tableName } from 'src/helper/constants/emtities.constant';
 import { templatePug } from 'src/helper/constants/template.constant';
 import { ApiResponse } from 'src/helper/interface/api.interface';
@@ -20,7 +22,7 @@ import { GetCourse } from 'src/helper/shared/get_course.shared';
 import { I18nUtils } from 'src/helper/utils/i18n-utils';
 import { CreateCourseDto, UpdateCourseDto } from 'src/validation/class_validation/course.validation';
 import { DatabaseValidation } from 'src/validation/existence/existence.validator';
-import { DataSource, Repository } from 'typeorm';
+import { DataSource, EntityManager, Repository } from 'typeorm';
 
 @Injectable()
 export class CourseService {
@@ -30,6 +32,7 @@ export class CourseService {
         @InjectRepository(CourseSubject) private readonly courseSubjectRepo: Repository<CourseSubject>,
         @InjectRepository(SupervisorCourse) private readonly supervisorCourseRepo: Repository<SupervisorCourse>,
         @InjectRepository(User) private readonly userRepo: Repository<User>,
+        @InjectRepository(UserSubject) private readonly userSubjectRepo: Repository<UserSubject>,
         private readonly databaseValidation: DatabaseValidation,
         private readonly i18nUtils: I18nUtils,
         private readonly dataSource: DataSource,
@@ -147,7 +150,7 @@ export class CourseService {
         const queryRunner = this.dataSource.createQueryRunner();
         await queryRunner.connect();
         await queryRunner.startTransaction();
-        
+
         try {
             const courseSubject = subjectIds.map(subjectId => {
                 return this.courseSubjectRepo.create({
@@ -161,7 +164,7 @@ export class CourseService {
             await queryRunner.commitTransaction();
         } catch (error) {
             await queryRunner.rollbackTransaction();
-            this.logger.error(`saveCourseSubjects failed: ${error?.message || error}`,error?.stack,'CourseService',
+            this.logger.error(`saveCourseSubjects failed: ${error?.message || error}`, error?.stack, 'CourseService',
             );
             throw new InternalServerErrorException(this.i18nUtils.translate('validation.server.internal_server_error', {}, lang));
         } finally {
@@ -388,7 +391,7 @@ export class CourseService {
         }
     }
 
-    private async getCourseById(savedUserCourse: UserCourse, lang: string) {
+    private async getCourseById(savedUserCourse: UserCourse, lang: string): Promise<Course> {
         const course: Course | null = await this.courseRepo.findOneBy({ courseId: savedUserCourse.course.courseId });
         if (!course) {
             throw new BadRequestException(this.i18nUtils.translate('validation.course.user_not_trainee', {}, lang));
@@ -396,7 +399,7 @@ export class CourseService {
         return course;
     }
 
-    private async sendEmail(email: string, subject: string, template: string, context: object, lang: string) {
+    private async sendEmail(email: string, subject: string, template: string, context: object, lang: string): Promise<void> {
         try {
             await this.mailerService.sendMail({
                 to: email,
@@ -409,7 +412,7 @@ export class CourseService {
         }
     }
 
-    async removeTraineeFromCourse(courseId: number, traineeId: number, lang: string) {
+    async removeTraineeFromCourse(courseId: number, traineeId: number, lang: string): Promise<ApiResponse> {
         const existing = await this.userCourseRepo.findOne({
             where: {
                 course: { courseId: courseId },
@@ -443,4 +446,94 @@ export class CourseService {
             throw new InternalServerErrorException(this.i18nUtils.translate('validation.server.internal_server_error', {}, lang));
         }
     }
-} 
+
+    async startCourse(courseId: number, lang: string): Promise<ApiResponse> {
+        const queryRunner = this.dataSource.createQueryRunner();
+        await queryRunner.connect();
+        await queryRunner.startTransaction();
+
+        try {
+            await this.changeStatusCourseSubject(courseId, lang, queryRunner.manager);
+            await this.findUserCourse(courseId, lang);
+            await this.assignSubjectsToUsersInCourse(courseId, lang, queryRunner.manager);
+
+            await queryRunner.commitTransaction();
+
+            return {
+                success: true,
+                message: this.i18nUtils.translate('validation.course.start_course_success'),
+            };
+
+        } catch (error) {
+            await queryRunner.rollbackTransaction();
+            this.logger.error('startCourse failed', error?.stack || error);
+            throw new InternalServerErrorException(this.i18nUtils.translate('validation.server.internal_server_error', {}, lang));
+
+        } finally {
+            await queryRunner.release();
+        }
+    }
+
+    private async findCourseSubject(courseId: number, lang: string): Promise<CourseSubject[]> {
+        const findCourse = await this.courseSubjectRepo.find({
+            where: {
+                course: { courseId: courseId, status: CourseStatus.ACTIVE },
+                status: CourseSubjectStatus.NOT_STARTED,
+            },
+            relations: ['course']
+        });
+
+        if (findCourse.length === 0) {
+            throw new BadRequestException(this.i18nUtils.translate('validation.course.not_found', {}, lang));
+        }
+        return findCourse;
+    }
+
+    private async changeStatusCourseSubject(courseId: number, lang: string, manager: EntityManager): Promise<void> {
+        const courses = await this.findCourseSubject(courseId, lang);
+
+        for (const course of courses) {
+            course.status = CourseSubjectStatus.START;
+        }
+
+        await manager.save(courses);
+    }
+
+    private async findUserCourse(courseId: number, lang: string): Promise<UserCourse[]> {
+        const userCourse = await this.userCourseRepo.find({
+            where: {
+                course: { courseId: courseId },
+                status: UserCourseStatus.RESIGN,
+            },
+            relations: ['user']
+        });
+
+        if (userCourse.length === 0) {
+            throw new BadRequestException(this.i18nUtils.translate('validation.course.trainee_not_found', {}, lang));
+        }
+
+        return userCourse;
+    }
+
+    private async assignSubjectsToUsersInCourse(courseId: number, lang: string, manager: EntityManager): Promise<void> {
+        const subjects = await this.findCourseSubject(courseId, lang);
+        const users = await this.findUserCourse(courseId, lang);
+
+        const newDataUserCourse = subjects.flatMap((subject) => {
+            return users.map((user) => {
+                const userId = user.user.userId;
+                const courseSubjectId = subject.courseSubjectId;
+
+                return this.userSubjectRepo.create({
+                    subjectProgress: firstUserSubjectProgress,
+                    status: UserSubjectStatus.NOT_STARTED,
+                    user: { userId: userId },
+                    courseSubject: { courseSubjectId: courseSubjectId }
+                });
+            });
+        });
+
+        await manager.save(newDataUserCourse);
+
+    }
+}

--- a/src/helper/constants/cron_expression.constant.ts
+++ b/src/helper/constants/cron_expression.constant.ts
@@ -8,3 +8,4 @@ export const CronExpression = {
 
 export const todayDate = new Date().toLocaleDateString('en-CA');
 export const firstCourseProgress = 0;
+export const firstUserSubjectProgress = 0;

--- a/src/i18n/en/validation.json
+++ b/src/i18n/en/validation.json
@@ -68,6 +68,7 @@
     "user_course_success": "You have been added to a course on S*learn!",
     "user_course_remove": "You have been removed from the course on S*learn!",
     "trainee_not_found": "Trainee does not exist in this course",
+    "start_course_success": "Course activated successfully",
     "name": {
       "isString": "Course name must be a string",
       "isNotEmpty": "Course name cannot be empty",

--- a/src/i18n/vi/validation.json
+++ b/src/i18n/vi/validation.json
@@ -71,6 +71,7 @@
     "user_course_success": "Bạn đã được thêm vào khóa học trên S*learn!",
     "user_course_remove": "Bạn đã bị xoá khỏi khoá trên S*learn!",
     "trainee_not_found": "Trainee không tồn tại trong khoá học này",
+    "start_course_success": "Đã kích hoạt khoá học thành công",
     "name": {
       "isString": "Tên khóa học phải là chuỗi",
       "isNotEmpty": "Tên khóa học không được để trống",


### PR DESCRIPTION
Bắt đầu một khóa học cụ thể bằng cách cập nhật trạng thái các môn học trong khóa học và phân công môn học cho tất cả học viên thuộc khóa học đó.
**Requirement**:

- Chỉ người dùng có vai trò ADMIN hoặc SUPERVISOR được phép gọi API.

- Khóa học phải ở trạng thái hợp lệ (đang hoạt động).

- Tất cả môn học trong khóa phải có trạng thái NOT_STARTED.

- Khóa học phải có học viên với trạng thái RESIGN.

**Solution**:

Tạo API POST /courses/:courseId/start trong controller để gọi service thực hiện logic.

Trong **service**:

- Mở transaction để đảm bảo tính toàn vẹn dữ liệu.

- Lấy danh sách các môn học chưa bắt đầu của khóa học và cập nhật trạng thái sang START.

- Lấy danh sách học viên của khóa học.

- Tạo các bản ghi UserSubject tương ứng cho mỗi cặp học viên – môn học với trạng thái NOT_STARTED.

- Lưu dữ liệu bằng manager.save() để nằm trong transaction.

- Nếu có lỗi xảy ra, transaction sẽ rollback và trả về lỗi phù hợp.