### PR TITLE
manage_course_subject

### DIFF
--- a/src/api/api.module.ts
+++ b/src/api/api.module.ts
@@ -5,8 +5,9 @@ import { UserModule } from './user/user.module';
 import { SourseModule } from './course/course.module';
 import { SubjectModule } from './subject/subject.module';
 import { TaskModule } from './task/task.module';
+import { CourseSubjectModule } from './course_subject/course_subject.module';
 
 @Module({
-    imports: [AuthModule, ValidationModule, UserModule, SourseModule, SubjectModule, TaskModule],
+    imports: [AuthModule, ValidationModule, UserModule, SourseModule, SubjectModule, TaskModule, CourseSubjectModule],
 })
 export class ApiModule {}

--- a/src/api/course_subject/course_subject.controller.ts
+++ b/src/api/course_subject/course_subject.controller.ts
@@ -1,0 +1,37 @@
+import { Body, Controller, Delete, Get, Param, Post } from '@nestjs/common';
+import { CourseSubjectService } from './course_subject.service';
+import { courseIdDto } from 'src/validation/class_validation/course.validation';
+import { Language } from 'src/helper/decorators/language.decorator';
+import { AuthRoles } from 'src/helper/decorators/auth_roles.decorator';
+import { Role } from 'src/database/dto/user.dto';
+import { subjectIdDto, SubjectIdsDto } from 'src/validation/class_validation/subject.validation';
+import { ApiResponse } from 'src/helper/interface/api.interface';
+import { CreateCourseWithSubjectsDto, GetByIdCourseWithSubjectsDto } from 'src/helper/interface/course_subject.interface';
+
+@Controller('course_subject')
+export class CourseSubjectController {
+    constructor(
+        private readonly courseSubjectService: CourseSubjectService,
+    ) { }
+
+    @AuthRoles(Role.ADMIN, Role.SUPERVISOR)
+    @Get(':courseId')
+    async getById(@Param() courseId: courseIdDto, @Language() lang: string): Promise<ApiResponse | CreateCourseWithSubjectsDto> {
+        const result = await this.courseSubjectService.getById(courseId.courseId, lang);
+        return result;
+    }
+
+    @AuthRoles(Role.ADMIN, Role.SUPERVISOR)
+    @Post(':courseId')
+    async create(@Param() courseId: courseIdDto, @Body() subjectId: SubjectIdsDto, @Language() lang: string): Promise<ApiResponse | GetByIdCourseWithSubjectsDto> {
+        const result = await this.courseSubjectService.create(courseId.courseId, subjectId.subjectIds, lang);
+        return result;
+    }
+
+    @AuthRoles(Role.ADMIN, Role.SUPERVISOR)
+    @Delete(':courseId/subjects')
+    async delete(@Param() courseId: courseIdDto, @Body() subjectId: SubjectIdsDto, @Language() lang: string):Promise<ApiResponse|void> {
+        const result = await this.courseSubjectService.delete(courseId.courseId, subjectId.subjectIds, lang);
+        return result;
+    }
+}

--- a/src/api/course_subject/course_subject.module.ts
+++ b/src/api/course_subject/course_subject.module.ts
@@ -1,0 +1,15 @@
+import { Module } from '@nestjs/common';
+import { CourseSubjectController } from './course_subject.controller';
+import { CourseSubjectService } from './course_subject.service';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { CourseSubject } from 'src/database/entities/course_subject.entity';
+import { I18nUtils } from 'src/helper/utils/i18n-utils';
+import { Course } from 'src/database/entities/course.entity';
+import { Subject } from 'src/database/entities/subject.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([CourseSubject,Course,Subject])],
+  controllers: [CourseSubjectController],
+  providers: [CourseSubjectService,I18nUtils]
+})
+export class CourseSubjectModule {}

--- a/src/api/course_subject/course_subject.service.ts
+++ b/src/api/course_subject/course_subject.service.ts
@@ -1,0 +1,154 @@
+import { BadRequestException, Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { CourseSubjectStatus } from 'src/database/dto/course_subject.dto';
+import { Course } from 'src/database/entities/course.entity';
+import { CourseSubject } from 'src/database/entities/course_subject.entity';
+import { Subject } from 'src/database/entities/subject.entity';
+import { CreateCourseWithSubjectsDto, GetByIdCourseWithSubjectsDto } from 'src/helper/interface/course_subject.interface';
+import { I18nUtils } from 'src/helper/utils/i18n-utils';
+import { DataSource, EntityManager, In, Repository } from 'typeorm';
+
+@Injectable()
+export class CourseSubjectService {
+    constructor(
+        @InjectRepository(CourseSubject) private readonly courseSubjectRepo: Repository<CourseSubject>,
+        @InjectRepository(Course) private readonly courseRepo: Repository<Course>,
+        @InjectRepository(Subject) private readonly subjectRepo: Repository<Subject>,
+        private readonly dataSource: DataSource,
+        private readonly i18nUtils: I18nUtils
+    ) { }
+
+    async getById(courseId: number, lang: string): Promise<CreateCourseWithSubjectsDto> {
+        const courseSubjects: CourseSubject[] = await this.courseSubjectRepo.find({
+            where: {
+                course: {
+                    courseId: courseId
+                }
+            },
+            relations: ['course', 'subject'],
+        });
+
+        if (courseSubjects.length === 0) {
+            throw new BadRequestException(this.i18nUtils.translate('validation.course_subject.subject_not_found'));
+        }
+
+        const course = {
+            courseId: courseSubjects[0].course.courseId,
+            name: courseSubjects[0].course.name,
+            description: courseSubjects[0].course.description,
+            status: courseSubjects[0].course.status,
+            start: courseSubjects[0].course.start,
+            end: courseSubjects[0].course.end,
+        };
+
+        const subjects = courseSubjects.map(({ subject }) => ({
+            subjectId: subject.subjectId,
+            name: subject.name,
+            description: subject.description,
+            studyDuration: subject.studyDuration,
+        }));
+
+        const datas: CreateCourseWithSubjectsDto = {
+            course: course,
+            subjects: subjects
+        };
+
+        return datas;
+    }
+
+    async create(courseId: number, subjectIds: number[], lang: string): Promise<GetByIdCourseWithSubjectsDto> {
+        return await this.dataSource.transaction(async (manager) => {
+            await this.validateBeforeCreateCourseSubject(courseId, subjectIds, lang, manager);
+            await this.checkCourseSubject(courseId, subjectIds, lang, manager);
+
+            const newCourseSubjects = subjectIds.map((subjectId) =>
+                manager.getRepository(CourseSubject).create({
+                    course: { courseId },
+                    subject: { subjectId },
+                    status: CourseSubjectStatus.NOT_STARTED,
+                })
+            );
+            await manager.getRepository(CourseSubject).save(newCourseSubjects);
+
+            const { course: dataCourse, subjects: dataSubjects } = await this.formatData(courseId, manager);
+
+            return {
+                course: dataCourse,
+                subjects: dataSubjects
+            };
+        });
+    }
+
+    private async validateBeforeCreateCourseSubject(courseId: number, subjectIds: number[], lang: string, manager: EntityManager): Promise<void> {
+        const course = await manager.getRepository(Course).findOneBy({ courseId });
+        if (!course) {
+            throw new BadRequestException(this.i18nUtils.translate('validation.course.not_found', {}, lang));
+        }
+
+        const subjects = await manager.getRepository(Subject).findBy({ subjectId: In(subjectIds) });
+        if (subjects.length !== subjectIds.length) {
+            throw new BadRequestException(this.i18nUtils.translate('validation.subject.subject_not_found', {}, lang));
+        }
+    }
+
+    private async checkCourseSubject(courseId: number, subjectIds: number[], lang: string, manager: EntityManager): Promise<void> {
+        const existing = await manager.getRepository(CourseSubject).find({
+            where: {
+                course: { courseId },
+                subject: In(subjectIds),
+            },
+        });
+
+        if (existing.length > 0) {
+            throw new BadRequestException(this.i18nUtils.translate('validation.course_subject.already_exists', {}, lang));
+        }
+    }
+
+    private async formatData(courseId: number, manager: EntityManager): Promise<GetByIdCourseWithSubjectsDto> {
+        const courseSubjects = await manager.getRepository(CourseSubject).find({
+            where: { course: { courseId } },
+            relations: ['course', 'subject'],
+        });
+
+        const subjects = courseSubjects.map((cs) => cs.subject);
+
+        const course = courseSubjects[0]?.course;
+        const dataCourse = {
+            courseId: course.courseId,
+            name: course.name,
+            description: course.description,
+            status: course.status,
+            start: course.start,
+            end: course.end,
+        };
+
+        const dataSubjects = subjects.map((s) => ({
+            subjectId: s.subjectId,
+            name: s.name,
+            description: s.description,
+            studyDuration: s.studyDuration,
+        }));
+
+        return { course: dataCourse, subjects: dataSubjects };
+    }
+
+    async delete(courseId: number, subjectIds: number[], lang: string) {
+        return await this.dataSource.transaction(async (manager) => {
+            for (const subjectId of subjectIds) {
+                const courseSubject = await manager.getRepository(CourseSubject).find({
+                    where: {
+                        course: { courseId },
+                        subject: { subjectId },
+                    },
+                });
+
+                if (courseSubject.length === 0) {
+                    throw new BadRequestException(this.i18nUtils.translate('validation.course_subject.course_subject_not_found', {}, lang),);
+                }
+
+                await manager.getRepository(CourseSubject).remove(courseSubject);
+            }
+        });
+    }
+
+}

--- a/src/api/subject/subject.service.ts
+++ b/src/api/subject/subject.service.ts
@@ -56,6 +56,8 @@ export class SubjectService {
                 subjects: savedSubject,
                 tasks: savedTasks
             }
+            
+            await queryRunner.commitTransaction();
 
             return data;
         } catch (error) {

--- a/src/helper/interface/course_subject.interface.ts
+++ b/src/helper/interface/course_subject.interface.ts
@@ -1,0 +1,41 @@
+export interface SubjectItem {
+    subjectId: number;
+    name: string;
+    description: string;
+    studyDuration: number;
+}
+
+export interface CourseItem {
+    courseId: number;
+    name: string;
+    description: string;
+    status: string;
+    start: string | Date;
+    end: string | Date;
+}
+
+export interface CreateCourseWithSubjectsDto {
+    course: CourseItem;
+    subjects: SubjectItem[];
+}
+
+export interface CourseDto {
+    courseId: number;
+    name: string;
+    description: string;
+    status: string;
+    start: Date | string;
+    end: Date | string;
+}
+
+export interface SubjectDto {
+    subjectId: number;
+    name: string;
+    description: string;
+    studyDuration: number;
+}
+
+export interface GetByIdCourseWithSubjectsDto {
+    course: CourseDto;
+    subjects: SubjectDto[];
+}

--- a/src/i18n/en/validation.json
+++ b/src/i18n/en/validation.json
@@ -99,6 +99,8 @@
     }
   },
   "course_subject": {
+    "already_exists": "The subject already exists in the course",
+    "course_subject_not_found": "No lesson or course exists",
     "courseId": {
       "isInt": "course_id must be an integer",
       "isNotEmpty": "course_id cannot be empty"

--- a/src/i18n/vi/validation.json
+++ b/src/i18n/vi/validation.json
@@ -102,6 +102,8 @@
     }
   },
   "course_subject": {
+    "already_exists": "Môn học đã tồn tại trong khoá học",
+    "course_subject_not_found": "Không tồn tại bài học hoặc khoá học nào",
     "courseId": {
       "isInt": "course_id phải là số nguyên",
       "isNotEmpty": "course_id không được để trống"

--- a/src/validation/class_validation/subject.validation.ts
+++ b/src/validation/class_validation/subject.validation.ts
@@ -8,6 +8,7 @@ import {
     IsArray,
     ArrayUnique,
     ArrayNotEmpty,
+    IsNumber,
 } from 'class-validator';
 import { DefaultLength } from 'src/helper/constants/emtities.constant';
 import { i18nValidationMessage } from 'src/helper/decorators/i18n-validation.decorator';
@@ -54,4 +55,12 @@ export class subjectIdDto {
     @IsNotEmpty(i18nValidationMessage('validation.userId.isNotEmpty'))
     @Type(() => Number)
     subjectId: number
+}
+
+export class SubjectIdsDto {
+    @IsArray(i18nValidationMessage('validation.subjectIds.mustBeArray'))
+    @IsNotEmpty(i18nValidationMessage('validation.subjectIds.isNotEmpty'))
+    @IsNumber({}, { each: true, ...i18nValidationMessage('validation.subjectIds.isNumber') })
+    @Type(() => Number)
+    subjectIds: number[];
 }


### PR DESCRIPTION
**Mô tả chức năng: Quản lý Course-Subject**
**API Get Course with Subjects:**
- URL: GET /course_subject/:courseId
- Mục đích: Lấy thông tin khóa học và danh sách môn học đã được gán vào khóa học đó.

**Chi tiết:**
- Trả về thông tin của khóa học (course) và các môn học (subject) liên kết.
- Nếu không tìm thấy dữ liệu course_subject tương ứng, sẽ trả về lỗi.

**API Assign Subjects to Course**
- URL: POST /course_subject/:courseId
- Mục đích: Gán thêm các môn học vào một khóa học.

**Chi tiết:**
- Kiểm tra tính hợp lệ của courseId và danh sách subjectIds.
- Kiểm tra trùng lặp: nếu đã tồn tại mối liên kết giữa course và subject, sẽ trả về lỗi.
- Tạo mới các bản ghi CourseSubject với trạng thái NOT_STARTED.
- Trả về thông tin khóa học và danh sách môn học đã được thêm mới.

**API Remove Subjects from Course**
- URL: DELETE /course_subject/:courseId/subjects
- Mục đích: Xóa các môn học đã gán ra khỏi khóa học.

**Chi tiết:**
- Với mỗi subjectId, kiểm tra xem mối liên kết course_subject có tồn tại hay không.
- Nếu không tồn tại thì trả về lỗi.
- Nếu có thì xóa bản ghi CourseSubject.

**Logic kiểm tra và xử lý (trong Service)**

- validateBeforeCreateCourseSubject: Xác thực sự tồn tại của course và subject.
- checkCourseSubject: Kiểm tra xem quan hệ course-subject đã tồn tại chưa để tránh trùng lặp.
- formatData: Chuẩn hóa dữ liệu trả về gồm thông tin course và danh sách subjects.