### PR TITLE
doc_api authController

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@nestjs/jwt": "^11.0.0",
         "@nestjs/platform-express": "^11.0.1",
         "@nestjs/schedule": "^6.0.0",
+        "@nestjs/swagger": "^11.2.0",
         "@nestjs/typeorm": "^11.0.0",
         "bcrypt": "^6.0.0",
         "bull": "^4.16.5",
@@ -30,6 +31,7 @@
         "pug": "^3.0.3",
         "reflect-metadata": "^0.2.2",
         "rxjs": "^7.8.1",
+        "swagger-ui-express": "^5.0.1",
         "typeorm": "^0.3.25",
         "typeorm-naming-strategies": "^4.1.0"
       },
@@ -2123,6 +2125,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/@microsoft/tsdoc": {
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.15.1.tgz",
+      "integrity": "sha512-4aErSrCR/On/e5G2hDP0wjooqDdauzEbIq8hIkIe5pXV0rtWJZvdCEKL0ykZxex+IxIwBp0eGeV48hQN07dXtw==",
+      "license": "MIT"
+    },
     "node_modules/@msgpackr-extract/msgpackr-extract-darwin-arm64": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-arm64/-/msgpackr-extract-darwin-arm64-3.0.3.tgz",
@@ -2982,6 +2990,26 @@
         "@nestjs/common": "^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0"
       }
     },
+    "node_modules/@nestjs/mapped-types": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nestjs/mapped-types/-/mapped-types-2.1.0.tgz",
+      "integrity": "sha512-W+n+rM69XsFdwORF11UqJahn4J3xi4g/ZEOlJNL6KoW5ygWSmBB2p0S2BZ4FQeS/NDH72e6xIcu35SfJnE8bXw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@nestjs/common": "^10.0.0 || ^11.0.0",
+        "class-transformer": "^0.4.0 || ^0.5.0",
+        "class-validator": "^0.13.0 || ^0.14.0",
+        "reflect-metadata": "^0.1.12 || ^0.2.0"
+      },
+      "peerDependenciesMeta": {
+        "class-transformer": {
+          "optional": true
+        },
+        "class-validator": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@nestjs/platform-express": {
       "version": "11.1.5",
       "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-11.1.5.tgz",
@@ -3112,6 +3140,39 @@
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@nestjs/swagger": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/@nestjs/swagger/-/swagger-11.2.0.tgz",
+      "integrity": "sha512-5wolt8GmpNcrQv34tIPUtPoV1EeFbCetm40Ij3+M0FNNnf2RJ3FyWfuQvI8SBlcJyfaounYVTKzKHreFXsUyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "@microsoft/tsdoc": "0.15.1",
+        "@nestjs/mapped-types": "2.1.0",
+        "js-yaml": "4.1.0",
+        "lodash": "4.17.21",
+        "path-to-regexp": "8.2.0",
+        "swagger-ui-dist": "5.21.0"
+      },
+      "peerDependencies": {
+        "@fastify/static": "^8.0.0",
+        "@nestjs/common": "^11.0.1",
+        "@nestjs/core": "^11.0.1",
+        "class-transformer": "*",
+        "class-validator": "*",
+        "reflect-metadata": "^0.1.12 || ^0.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@fastify/static": {
+          "optional": true
+        },
+        "class-transformer": {
+          "optional": true
+        },
+        "class-validator": {
+          "optional": true
+        }
       }
     },
     "node_modules/@nestjs/testing": {
@@ -3254,6 +3315,13 @@
       "funding": {
         "url": "https://opencollective.com/pkgr"
       }
+    },
+    "node_modules/@scarf/scarf": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.4.0.tgz",
+      "integrity": "sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0"
     },
     "node_modules/@sec-ant/readable-stream": {
       "version": "0.4.1",
@@ -8244,6 +8312,7 @@
       "resolved": "https://registry.npmjs.org/get-port/-/get-port-5.1.1.tgz",
       "integrity": "sha512-g/Q1aTSDOxFpchXC4i8ZWvxA1lnPqx/JHqcpIw0/LX9T8x/GBbi6YnlN5nhaKIFkT8oFsscUKgDJYxfwfS6QsQ==",
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=8"
       },
@@ -8737,30 +8806,6 @@
       "license": "ISC",
       "dependencies": {
         "kind-of": "^6.0.2"
-      }
-    },
-    "node_modules/ioredis": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.7.0.tgz",
-      "integrity": "sha512-NUcA93i1lukyXU+riqEyPtSEkyFq8tX90uL659J+qpCZ3rEdViB/APC58oAhIh3+bJln2hzdlZbBZsGNrlsR8g==",
-      "license": "MIT",
-      "dependencies": {
-        "@ioredis/commands": "^1.3.0",
-        "cluster-key-slot": "^1.1.0",
-        "debug": "^4.3.4",
-        "denque": "^2.1.0",
-        "lodash.defaults": "^4.2.0",
-        "lodash.isarguments": "^3.1.0",
-        "redis-errors": "^1.2.0",
-        "redis-parser": "^3.0.0",
-        "standard-as-callback": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=12.22.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/ioredis"
       }
     },
     "node_modules/ipaddr.js": {
@@ -10173,12 +10218,6 @@
       "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
       "license": "MIT"
     },
-    "node_modules/lodash.isarguments": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
-      "integrity": "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==",
-      "license": "MIT"
-    },
     "node_modules/lodash.isboolean": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
@@ -10585,37 +10624,6 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
-    },
-    "node_modules/msgpackr": {
-      "version": "1.11.5",
-      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.11.5.tgz",
-      "integrity": "sha512-UjkUHN0yqp9RWKy0Lplhh+wlpdt9oQBYgULZOiFhV3VclSF1JnSQWZ5r9gORQlNYaUKQoR8itv7g7z1xDDuACA==",
-      "license": "MIT",
-      "optionalDependencies": {
-        "msgpackr-extract": "^3.0.2"
-      }
-    },
-    "node_modules/msgpackr-extract": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/msgpackr-extract/-/msgpackr-extract-3.0.3.tgz",
-      "integrity": "sha512-P0efT1C9jIdVRefqjzOQ9Xml57zpOXnIuS+csaB4MdZbTdmGDLo8XhzBG1N7aO11gKDDkJvBLULeFTo46wwreA==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "node-gyp-build-optional-packages": "5.2.2"
-      },
-      "bin": {
-        "download-msgpackr-prebuilds": "bin/download-prebuilds.js"
-      },
-      "optionalDependencies": {
-        "@msgpackr-extract/msgpackr-extract-darwin-arm64": "3.0.3",
-        "@msgpackr-extract/msgpackr-extract-darwin-x64": "3.0.3",
-        "@msgpackr-extract/msgpackr-extract-linux-arm": "3.0.3",
-        "@msgpackr-extract/msgpackr-extract-linux-arm64": "3.0.3",
-        "@msgpackr-extract/msgpackr-extract-linux-x64": "3.0.3",
-        "@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.3"
-      }
     },
     "node_modules/multer": {
       "version": "2.0.2",
@@ -11965,27 +11973,6 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
-    "node_modules/redis-errors": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
-      "integrity": "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/redis-parser": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
-      "integrity": "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==",
-      "license": "MIT",
-      "dependencies": {
-        "redis-errors": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/reflect-metadata": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
@@ -12805,12 +12792,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/standard-as-callback": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
-      "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==",
-      "license": "MIT"
-    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -13147,6 +13128,30 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/swagger-ui-dist": {
+      "version": "5.21.0",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.21.0.tgz",
+      "integrity": "sha512-E0K3AB6HvQd8yQNSMR7eE5bk+323AUxjtCz/4ZNKiahOlPhPJxqn3UPIGs00cyY/dhrTDJ61L7C/a8u6zhGrZg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@scarf/scarf": "=1.4.0"
+      }
+    },
+    "node_modules/swagger-ui-express": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-5.0.1.tgz",
+      "integrity": "sha512-SrNU3RiBGTLLmFU8GIJdOdanJTl4TOmT27tt3bWWHppqYmAZ6IDuEuBvMU6nZq0zLEe6b/1rACXCgLZqO6ZfrA==",
+      "license": "MIT",
+      "dependencies": {
+        "swagger-ui-dist": ">=5.0.0"
+      },
+      "engines": {
+        "node": ">= v0.10.32"
+      },
+      "peerDependencies": {
+        "express": ">=4.0.0 || >=5.0.0-beta"
       }
     },
     "node_modules/symbol-observable": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@nestjs/jwt": "^11.0.0",
     "@nestjs/platform-express": "^11.0.1",
     "@nestjs/schedule": "^6.0.0",
+    "@nestjs/swagger": "^11.2.0",
     "@nestjs/typeorm": "^11.0.0",
     "bcrypt": "^6.0.0",
     "bull": "^4.16.5",
@@ -43,6 +44,7 @@
     "pug": "^3.0.3",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1",
+    "swagger-ui-express": "^5.0.1",
     "typeorm": "^0.3.25",
     "typeorm-naming-strategies": "^4.1.0"
   },

--- a/src/api/auth/auth.controller.ts
+++ b/src/api/auth/auth.controller.ts
@@ -1,5 +1,4 @@
 import { Body, Controller, Get, Post, Req } from '@nestjs/common';
-import { Request } from 'express';
 import { AuthDto } from 'src/validation/auth_validation/auth.validation';
 import { AuthService } from './auth.service';
 import { CreateUserDto } from 'src/validation/class_validation/user.validation';
@@ -7,30 +6,55 @@ import { Language } from 'src/helper/decorators/language.decorator';
 import { Public } from 'src/helper/decorators/metadata.decorator';
 import { User } from 'src/database/entities/user.entity';
 import { UserDecorator } from 'src/helper/decorators/user.decorator';
+import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
+import { ApiResponseLogin } from 'src/helper/swagger/auth/login_response.decorator';
+import { ApiResponseRegister } from 'src/helper/swagger/auth/response_regiser.decorator';
+import { LoginResponse, RegisterResponse, UserProfileResponse } from 'src/helper/interface/auth.interface';
+import { ApiResponse } from 'src/helper/interface/api.interface';
+import { I18nUtils } from 'src/helper/utils/i18n-utils';
+import { ApiResponseMe } from 'src/helper/swagger/auth/me_response.decorator';
 
+@ApiTags('auths')
 @Controller('auth')
 export class AuthController {
     constructor(
         private readonly authService: AuthService,
+        private readonly i18nUtils: I18nUtils,
     ) { }
 
+    @ApiResponseLogin()
     @Public()
     @Post('login')
-    async login(@Body() userInput: AuthDto, @Language() lang: string) {
-        const result = await this.authService.login(userInput,lang);
-        return result;
+    async login(@Body() userInput: AuthDto, @Language() lang: string): Promise<ApiResponse | LoginResponse> {
+        const result = await this.authService.login(userInput, lang);
+        return {
+            success: true,
+            message: this.i18nUtils.translate('validation.auth.login_success', {}, lang),
+            data: result
+        };
     }
 
+    @ApiResponseRegister()
     @Public()
     @Post('register')
-    async register(@Body() userInput: CreateUserDto, @Language() lang: string) {
-        const result = await this.authService.register(userInput,lang);
-        return result;
+    async register(@Body() userInput: CreateUserDto, @Language() lang: string): Promise<ApiResponse | RegisterResponse> {
+        const result = await this.authService.register(userInput, lang);
+        return {
+            success: true,
+            message: this.i18nUtils.translate('validation.auth.register_success', {}, lang),
+            data: result
+        }
     }
 
+    @ApiBearerAuth('access-token')
+    @ApiResponseMe()
     @Get('me')
-    async getProfile(@UserDecorator() user: User, @Language() lang: string) {
-        const result = await this.authService.getProfile(user,lang);
-        return result;
+    async getProfile(@UserDecorator() user: User, @Language() lang: string): Promise<ApiResponse | UserProfileResponse> {
+        const result = await this.authService.getProfile(user, lang);
+        return {
+            success: true,
+            message: this.i18nUtils.translate('validation.response_api.success', {}, lang),
+            data: result
+        }
     }
 }

--- a/src/api/course/course.controller.ts
+++ b/src/api/course/course.controller.ts
@@ -8,6 +8,7 @@ import { QueryParam, UserDecorator } from 'src/helper/decorators/user.decorator'
 import { User } from 'src/database/entities/user.entity';
 import { AssignSupervisorDto } from 'src/validation/class_validation/supervisor_course.validation';
 import { userIdDto } from 'src/validation/class_validation/user.validation';
+import { ApiExcludeEndpoint } from '@nestjs/swagger';
 
 @Controller('course')
 export class CourseController {
@@ -29,7 +30,8 @@ export class CourseController {
         const result = await this.courseService.getById(courseId.courseId, user, lang);
         return result;
     }
-
+    
+    @ApiExcludeEndpoint()
     @AuthRoles(Role.ADMIN, Role.SUPERVISOR)
     @Post('')
     async create(@Body() courseInput: CreateCourseDto, @UserDecorator('userId') userId: number, @Language() lang: string) {
@@ -37,6 +39,7 @@ export class CourseController {
         return result;
     }
 
+    @ApiExcludeEndpoint()
     @AuthRoles(Role.ADMIN, Role.SUPERVISOR)
     @Delete(':courseId')
     async delete(@Param() courseId: courseIdDto, @Language() lang: string) {
@@ -44,6 +47,7 @@ export class CourseController {
         return result;
     }
 
+    @ApiExcludeEndpoint()
     @AuthRoles(Role.ADMIN, Role.SUPERVISOR)
     @Put(':courseId')
     async update(@Body() courseInput: UpdateCourseDto, @Param() courseId: courseIdDto, @Language() lang: string) {
@@ -51,6 +55,7 @@ export class CourseController {
         return result;
     }
 
+    @ApiExcludeEndpoint()
     @AuthRoles(Role.ADMIN)
     @Post(':courseId/supervisor')
     async assignSupervisorToCourse(@Param() courseId: courseIdDto, @Body() supervisorId: AssignSupervisorDto, @Language() lang: string) {
@@ -58,6 +63,7 @@ export class CourseController {
         return result;
     }
 
+    @ApiExcludeEndpoint()
     @AuthRoles(Role.ADMIN)
     @Delete(':courseId/supervisor/:supervisorId')
     async removeSupervisorFromCourse(@Param() param: { courseId: number; supervisorId: number }, @Language() lang: string) {
@@ -66,6 +72,7 @@ export class CourseController {
         return result;
     }
 
+    @ApiExcludeEndpoint()
     @AuthRoles(Role.ADMIN, Role.SUPERVISOR)
     @Post(':courseId/trainee')
     async assignTraineeToCourse(@Param() courseId: courseIdDto, @Body() traineeId: userIdDto, @Language() lang: string) {
@@ -73,6 +80,7 @@ export class CourseController {
         return result;
     }
 
+    @ApiExcludeEndpoint()
     @AuthRoles(Role.ADMIN, Role.SUPERVISOR)
     @Delete(':courseId/trainee/:traineeId')
     async removeTraineeFromCourse(@Param() param: { courseId: number; traineeId: number }, @Language() lang: string) {
@@ -81,6 +89,7 @@ export class CourseController {
         return result;
     }
 
+    @ApiExcludeEndpoint()
     @AuthRoles(Role.ADMIN, Role.SUPERVISOR)
     @Post(':courseId/start')
     async startCourse(@Param() courseId: courseIdDto, @Language() lang: string) {
@@ -88,6 +97,7 @@ export class CourseController {
         return result;
     }
 
+    @ApiExcludeEndpoint()
     @AuthRoles(Role.ADMIN, Role.SUPERVISOR)
     @Post(':courseId/finish')
     async finishCourse(@Param() courseId: courseIdDto, @Language() lang: string) {

--- a/src/api/course_subject/course_subject.controller.ts
+++ b/src/api/course_subject/course_subject.controller.ts
@@ -8,7 +8,9 @@ import { subjectIdDto, SubjectIdsDto } from 'src/validation/class_validation/sub
 import { ApiResponse } from 'src/helper/interface/api.interface';
 import { CreateCourseWithSubjectsDto, DeleteCourseSubjectResult, GetByIdCourseWithSubjectsDto } from 'src/helper/interface/course_subject.interface';
 import { I18nUtils } from 'src/helper/utils/i18n-utils';
+import { ApiExcludeController } from '@nestjs/swagger';
 
+@ApiExcludeController()
 @Controller('course_subject')
 export class CourseSubjectController {
     constructor(

--- a/src/api/subject/subject.controller.ts
+++ b/src/api/subject/subject.controller.ts
@@ -10,6 +10,9 @@ import { Task } from 'src/database/entities/task.entity';
 import { Subject } from 'src/database/entities/subject.entity';
 import { ApiResponse } from 'src/helper/interface/api.interface';
 import { I18nUtils } from 'src/helper/utils/i18n-utils';
+import { ApiExcludeController } from '@nestjs/swagger';
+
+@ApiExcludeController()
 @Controller('subject')
 export class SubjectController {
     constructor(

--- a/src/api/task/task.controller.ts
+++ b/src/api/task/task.controller.ts
@@ -7,7 +7,9 @@ import { ApiResponse } from 'src/helper/interface/api.interface';
 import { TaskWithSubjectDto } from 'src/helper/interface/task.interface';
 import { Task } from 'src/database/entities/task.entity';
 import { I18nUtils } from 'src/helper/utils/i18n-utils';
+import { ApiExcludeController } from '@nestjs/swagger';
 
+@ApiExcludeController()
 @Controller('task')
 export class TaskController {
     constructor(

--- a/src/api/user/supervisor/supervisor.controller.ts
+++ b/src/api/user/supervisor/supervisor.controller.ts
@@ -7,7 +7,9 @@ import { Language } from 'src/helper/decorators/language.decorator';
 import { Public } from 'src/helper/decorators/metadata.decorator';
 import { ChangePasswordDto } from 'src/validation/auth_validation/auth.validation';
 import { JwtBlacklistGuard } from 'src/middleware/jwt_blacklist.guard';
+import { ApiExcludeController } from '@nestjs/swagger';
 
+@ApiExcludeController()
 @Controller('supervisor')
 export class SupervisorController {
     constructor(private readonly supervisorService: SupervisorService) { }

--- a/src/api/user/trainee/trainee.controller.ts
+++ b/src/api/user/trainee/trainee.controller.ts
@@ -4,7 +4,9 @@ import { CreateUserDto, UpdateUserDto, userIdDto } from 'src/validation/class_va
 import { Language } from 'src/helper/decorators/language.decorator';
 import { Role } from 'src/database/dto/user.dto';
 import { AuthRoles } from 'src/helper/decorators/auth_roles.decorator';
+import { ApiExcludeController} from '@nestjs/swagger';
 
+@ApiExcludeController()
 @Controller('trainee')
 export class TraineeController {
     constructor(

--- a/src/api/user/user.controller.ts
+++ b/src/api/user/user.controller.ts
@@ -6,6 +6,7 @@ import { UserDecorator } from 'src/helper/decorators/user.decorator';
 import { User } from 'src/database/entities/user.entity';
 import { Role } from 'src/database/dto/user.dto';
 import { AuthRoles } from 'src/helper/decorators/auth_roles.decorator';
+import { ApiExcludeEndpoint } from '@nestjs/swagger';
 
 @Controller('user')
 export class UserController {
@@ -25,6 +26,7 @@ export class UserController {
         return result;
     }
 
+    @ApiExcludeEndpoint()
     @Get(':userId')
     @AuthRoles(Role.ADMIN, Role.SUPERVISOR)
     async viewProfile(@Param('userId') userId: number, @UserDecorator('role') userRole: string, @Language() lang: string) {

--- a/src/api/user_subject/user_subject.controller.ts
+++ b/src/api/user_subject/user_subject.controller.ts
@@ -10,6 +10,7 @@ import { Role } from 'src/database/dto/user.dto';
 import { traineeIdDto } from 'src/validation/class_validation/user.validation';
 import { ApiResponse } from 'src/helper/interface/api.interface';
 import { ActivityHistoryDto, SubjectWithTasksDto, TraineeCourseProgressDto, TraineeInCourseDto } from 'src/helper/interface/user_subject.interface';
+import { ApiExcludeEndpoint } from '@nestjs/swagger';
 
 @Controller('user_subject')
 export class UserSubjectController {
@@ -18,6 +19,7 @@ export class UserSubjectController {
         private readonly i18nUtils: I18nUtils
     ) { }
 
+    @ApiExcludeEndpoint()
     @AuthRoles(Role.SUPERVISOR)
     @Post(':userSubjectId/start')
     async startSubject(@Param() userSubjectId: UserSubjectIdDto, @UserDecorator() user: User, @Language() lang: string): Promise<ApiResponse> {
@@ -52,12 +54,14 @@ export class UserSubjectController {
         return result;
     }
 
+    @ApiExcludeEndpoint()
     @AuthRoles(Role.SUPERVISOR, Role.ADMIN)
     @Get(':courseId/trainee/:traineeId/progress')
     async getTraineeProgress(@Param('courseId') courseId: number, @Param('traineeId') traineeId: number, @UserDecorator() user: User, @Language() lang: string): Promise<ApiResponse | TraineeCourseProgressDto> {
         return this.userSubjectService.getTraineeCourseProgress(courseId, traineeId, user, lang);
     }
 
+    @ApiExcludeEndpoint()
     @AuthRoles(Role.SUPERVISOR, Role.ADMIN)
     @Get(':courseId/trainees')
     async listTraineesInCourse(@Param('courseId') courseId: number, @UserDecorator() user: User, @Language() lang: string): Promise<ApiResponse | TraineeInCourseDto[]> {

--- a/src/helper/interface/auth.interface.ts
+++ b/src/helper/interface/auth.interface.ts
@@ -1,0 +1,23 @@
+export interface LoginResponse {
+    user: {
+        id: number,
+        name: string,
+        role: string,
+    },
+    token: string,
+}
+
+export interface RegisterResponse {
+    id: number,
+    email: string,
+    name: string,
+    role: string,
+    status: string,
+}
+
+export interface UserProfileResponse {
+    id: number,
+    userName: string,
+    email: string,
+    role: string,
+}

--- a/src/helper/swagger/auth/login_response.decorator.ts
+++ b/src/helper/swagger/auth/login_response.decorator.ts
@@ -1,0 +1,48 @@
+import { applyDecorators } from '@nestjs/common';
+import { ApiBody, ApiOperation, ApiResponse } from '@nestjs/swagger';
+import { LoginSuccessResponseDto } from 'src/validation/api_document/auth/login/success_response.validation';
+import { ErrorResponseDto } from 'src/validation/api_document/error/error.validation';
+import { ServerErrorResponseDto } from 'src/validation/api_document/error/server_error.validation';
+import { AuthDto } from 'src/validation/auth_validation/auth.validation';
+
+export function ApiResponseLogin() {
+    return applyDecorators(
+        ApiOperation({
+            summary: 'Đăng nhập người dùng',
+            description: 'Xác thực người dùng bằng email và mật khẩu để nhận access token',
+        }),
+
+        ApiBody({
+            type: AuthDto,
+            description: 'Thông tin đăng nhập của người dùng',
+            examples: {
+                example1: {
+                    summary: 'Ví dụ đăng nhập với tài khoản Admin',
+                    value: {
+                        email: 'admin123@gmail.com',
+                        password: 'Namnam16@',
+                    },
+                },
+            },
+        }),
+
+        ApiResponse({
+            status: 200,
+            description: 'Đăng nhập thành công',
+            type: LoginSuccessResponseDto,
+        }),
+
+        ApiResponse({
+            status: 400,
+            description:
+                'Lỗi xác thực. Các lỗi khác cũng trả về định dạng giống, chỉ thay đổi `status`, `message`, `code`, `path`',
+            type: ErrorResponseDto
+        }),
+
+        ApiResponse({
+            status: 500,
+            description: 'Lỗi hệ thống, có thể do server hoặc cơ sở dữ liệu',
+            type: ServerErrorResponseDto,
+        }),
+    );
+}

--- a/src/helper/swagger/auth/me_response.decorator.ts
+++ b/src/helper/swagger/auth/me_response.decorator.ts
@@ -1,0 +1,26 @@
+import { applyDecorators } from '@nestjs/common';
+import { ApiOperation, ApiResponse } from '@nestjs/swagger';
+import { MeSuccessResponseDto } from 'src/validation/api_document/auth/me/success_response.validation';
+import { ErrorResponseDto } from 'src/validation/api_document/error/error.validation';
+
+export function ApiResponseMe() {
+    return applyDecorators(
+        ApiOperation({
+            summary: 'Thông tin người dùng sau khi đăng nhập thành công',
+            description: 'Cho phép lấy thông tin đăng nhập khi người dùng đăng nhập thành công nhằm hiển thị thông tin phục vụ cho mục đích UX/UI',
+        }),
+
+        ApiResponse({
+            status: 200,
+            description: 'Thành công',
+            type: MeSuccessResponseDto,
+        }),
+
+        ApiResponse({
+            status: 404,
+            description:
+                'Lỗi xác thực. Các lỗi khác cũng trả về định dạng giống, chỉ thay đổi `status`, `message`, `code`, `path`',
+            type: ErrorResponseDto,
+        }),
+    );
+}

--- a/src/helper/swagger/auth/response_regiser.decorator.ts
+++ b/src/helper/swagger/auth/response_regiser.decorator.ts
@@ -1,0 +1,49 @@
+import { applyDecorators } from '@nestjs/common';
+import { ApiBody, ApiOperation, ApiResponse } from '@nestjs/swagger';
+import { RegisterSuccessResponseDto } from 'src/validation/api_document/auth/register/success_response.validation';
+import { ErrorResponseDto } from 'src/validation/api_document/error/error.validation';
+import { ServerErrorResponseDto } from 'src/validation/api_document/error/server_error.validation';
+import { AuthDto } from 'src/validation/auth_validation/auth.validation';
+
+export function ApiResponseRegister() {
+    return applyDecorators(
+        ApiOperation({
+            summary: 'Đăng ký người dùng"',
+            description: 'Cho phép đăng ký người dùng với các thông tin như email, name, password role là TRAINEE',
+        }),
+
+        ApiBody({
+            type: AuthDto,
+            description: 'Thông tin người dùng',
+            examples: {
+                example1: {
+                    summary: 'Ví dụ đăng ký thông tin người dùng',
+                    value: {
+                        userName: 'trainee nè',
+                        email: 'trainee123@gmail.com',
+                        password: 'Namnam16@',
+                    },
+                },
+            },
+        }),
+
+        ApiResponse({
+            status: 200,
+            description: 'Đăng ký thành công',
+            type: RegisterSuccessResponseDto,
+        }),
+
+        ApiResponse({
+            status: 400,
+            description:
+                'Lỗi xác thực. Các lỗi khác cũng trả về định dạng giống, chỉ thay đổi `status`, `message`, `code`, `path`',
+            type: ErrorResponseDto,
+        }),
+
+        ApiResponse({
+            status: 500,
+            description: 'Lỗi hệ thống, có thể do server hoặc cơ sở dữ liệu',
+            type: ServerErrorResponseDto,
+        }),
+    );
+}

--- a/src/i18n/vi/validation.json
+++ b/src/i18n/vi/validation.json
@@ -29,6 +29,7 @@
   "auth": {
     "invalid_credentials": "Email hoặc mật khẩu không đúng",
     "login_success": "Đăng nhập thành công",
+    "login_fail": "Đăng nhập thành công",
     "register_success": "Đăng ký thành công",
     "email_exists": "Email đã tồn tại",
     "token_missing": "Token không được cung cấp",

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,9 +7,24 @@ import { Language } from './helper/decorators/language.decorator';
 import { asyncLocalStorage } from './middleware/language.middleware';
 import { LanguageRequest } from './helper/constants/lang.constant';
 import * as path from 'path';
+import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+
+  const config = new DocumentBuilder()
+    .setTitle('Training System')
+    .setDescription('Tài liệu API cho hệ thống Training System')
+    .setVersion('1.0')
+    .addBearerAuth({
+      type: 'http',
+      scheme: 'bearer',
+      bearerFormat: 'JWT',
+    }, 'access-token')
+    .build();
+
+  const document = SwaggerModule.createDocument(app, config);
+  SwaggerModule.setup('api_docs', app, document);
 
   const expressApp = app.getHttpAdapter().getInstance();
   expressApp.set('views', path.join(__dirname, '..', 'src', 'templates', 'email'));
@@ -36,7 +51,7 @@ async function bootstrap() {
                 }
               }),
             );
-            return translatedMessages.join(', ') ;
+            return translatedMessages.join(', ');
           }),
         );
         throw new BadRequestException({

--- a/src/validation/api_document/auth/login/success_response.validation.ts
+++ b/src/validation/api_document/auth/login/success_response.validation.ts
@@ -1,0 +1,28 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class LoginSuccessResponseDto {
+  @ApiProperty({ example: true })
+  success: boolean;
+
+  @ApiProperty({ example: 'Đăng nhập thành công' })
+  message: string;
+
+  @ApiProperty({
+    example: {
+      user: {
+        id: 4,
+        name: 'Admin',
+        role: 'ADMIN',
+      },
+      token: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...',
+    },
+  })
+  data: {
+    user: {
+      id: number;
+      name: string;
+      role: string;
+    };
+    token: string;
+  };
+}

--- a/src/validation/api_document/auth/me/success_response.validation.ts
+++ b/src/validation/api_document/auth/me/success_response.validation.ts
@@ -1,0 +1,24 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class MeSuccessResponseDto {
+    @ApiProperty({ example: true })
+    success: boolean;
+
+    @ApiProperty({ example: 'Thành công' })
+    message: string;
+
+    @ApiProperty({
+        example: {
+            id: 1,
+            userName: "Supervisor",
+            email: "yonex12360@gmail.com",
+            role: "SUPERVISOR"
+        },
+    })
+    data: {
+        id: 1,
+        userName: "Supervisor",
+        email: "yonex12360@gmail.com",
+        role: "SUPERVISOR"
+    };
+}

--- a/src/validation/api_document/auth/register/success_response.validation.ts
+++ b/src/validation/api_document/auth/register/success_response.validation.ts
@@ -1,0 +1,26 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class RegisterSuccessResponseDto {
+    @ApiProperty({ example: true })
+    success: boolean;
+
+    @ApiProperty({ example: 'Đăng ký thành công' })
+    message: string;
+
+    @ApiProperty({
+        example: {
+            id: 4,
+            name: 'trainee',
+            email: "trainee@gmail.com",
+            role: 'TRAINEE',
+            status: 'ACTIVE'
+        },
+    })
+    data: {
+        id: number;
+        name: string;
+        email: string;
+        role: string;
+        status: string
+    };
+}

--- a/src/validation/api_document/error/error.validation.ts
+++ b/src/validation/api_document/error/error.validation.ts
@@ -1,0 +1,18 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class ErrorResponseDto {
+    @ApiProperty({ example: 'Thông báo lỗi cụ thể' })
+    message: string;
+
+    @ApiProperty({ example: 400, description: 'Mã lỗi HTTP, có thể là 400, 401, 403, 404,...', })
+    code: number;
+
+    @ApiProperty({
+        example: '2025-08-06T02:30:46.913Z',
+        format: 'date-time',
+    })
+    timestamp: string;
+
+    @ApiProperty({ example: '/duong-dan-api' })
+    path: string;
+}

--- a/src/validation/api_document/error/server_error.validation.ts
+++ b/src/validation/api_document/error/server_error.validation.ts
@@ -1,0 +1,9 @@
+import { ApiProperty } from "@nestjs/swagger";
+
+export class ServerErrorResponseDto {
+    @ApiProperty({ example: 'Lỗi máy chủ nội bộ' })
+    message: string;
+
+    @ApiProperty({ example: 500 })
+    code: number;
+}


### PR DESCRIPTION
**Chức năng: Viết tài liệu (document) Swagger cho các API xác thực (auth.controller.ts)**

**Nội dung thay đổi:**

- Thêm các decorator Swagger cho các endpoint đăng nhập (/auth/login), đăng ký (/auth/register), và lấy thông tin người dùng (/auth/me) trong auth.controller.ts.

**Tạo các file response DTO cho các trường hợp thành công và lỗi, bao gồm:**
- LoginSuccessResponseDto
- RegisterSuccessResponseDto
- MeSuccessResponseDto
- ErrorResponseDto
- ServerErrorResponseDto

**Viết các decorator Swagger riêng biệt cho từng endpoint:**
- ApiResponseLogin
- ApiResponseRegister
- ApiResponseMe
- Mỗi decorator mô tả chi tiết request body, response mẫu, các trường hợp lỗi, và ví dụ minh họa cho từng API.
- Đảm bảo tài liệu API rõ ràng, dễ hiểu, hỗ trợ tốt cho frontend và các bên tích hợp.

Mục đích:
- Chuẩn hóa tài liệu API cho module xác thực, giúp các developer dễ dàng hiểu và sử dụng các endpoint.
- Hỗ trợ tự động sinh tài liệu Swagger UI, phục vụ kiểm thử và tích hợp hệ thống.