### PR TITLE
document_api user_course,user_task

### DIFF
--- a/src/api/reporting/reporting.service.ts
+++ b/src/api/reporting/reporting.service.ts
@@ -1,4 +1,4 @@
-import { BadRequestException, Injectable, Logger, NotFoundException } from '@nestjs/common';
+import { BadRequestException, ForbiddenException, Injectable, Logger, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Role } from 'src/database/dto/user.dto';
 import { UserTaskStatus } from 'src/database/dto/user_task.dto';
@@ -10,6 +10,7 @@ import { User } from 'src/database/entities/user.entity';
 import { UserCourse } from 'src/database/entities/user_course.entity';
 import { UserSubject } from 'src/database/entities/user_subject.entity';
 import { UserTask } from 'src/database/entities/user_task.entity';
+import { maxProgress } from 'src/helper/constants/cron_expression.constant';
 import { ActivityLogDto, ReportResponseDto } from 'src/helper/interface/reporting.interface';
 import { GetCourse } from 'src/helper/shared/get_course.shared';
 import { I18nUtils } from 'src/helper/utils/i18n-utils';
@@ -33,7 +34,7 @@ export class ReportingService {
     ) { }
 
     async getReportData(filter: ReportFilterDto, user: User, lang: string): Promise<ReportResponseDto> {
-        const { startDate, endDate, courseId, type } = filter;
+        const { startDate, endDate, courseId } = filter;
 
         const query = this.dataSource
             .getRepository(UserTask)
@@ -41,99 +42,187 @@ export class ReportingService {
             .innerJoinAndSelect('userTask.userSubject', 'userSubject')
             .innerJoin('userSubject.courseSubject', 'courseSubject')
             .innerJoin('courseSubject.course', 'course')
-            .where('userTask.assignedAt BETWEEN :start AND :end', { start: startDate, end: endDate });
+            .where('userSubject.startedAt BETWEEN :start AND :end', {
+                start: startDate,
+                end: endDate,
+            });
 
         if (courseId) {
             query.andWhere('course.courseId = :courseId', { courseId });
         }
 
         if (user.role === Role.SUPERVISOR) {
-            query.innerJoin('course.supervisorCourses', 'sc')
-                .andWhere('sc.supervisor_id = :supervisorId', { supervisorId: user.userId });
+            query
+                .innerJoin('course.supervisorCourses', 'supervisorCourse')
+                .andWhere('supervisorCourse.supervisor_id = :supervisorId', {
+                    supervisorId: user.userId,
+                });
         }
 
-        const tasks = await query.select([
-            'userTask.userTaskId',
-            'userTask.status',
-            'userSubject.userSubjectId',
-            'userSubject.subjectProgress',
-        ]).getMany();
+        const tasks = await query
+            .select([
+                'userTask.userTaskId',
+                'userTask.status',
+                'userSubject.userSubjectId',
+                'userSubject.subjectProgress',
+            ])
+            .getMany();
 
-        if (!tasks.length) {
-            throw new NotFoundException({ message: this.i18nUtils.translate('validation.report.not_found', { lang }), });
+        if (tasks.length === 0) {
+            throw new NotFoundException(this.i18nUtils.translate('validation.report.not_found',{},lang));
         }
 
         return this.buildReportData(tasks);
     }
 
-    private async buildReportData(tasks: UserTask[]): Promise<ReportResponseDto> {
+    private buildReportData(tasks: UserTask[]): ReportResponseDto {
         const totalTasks = tasks.length;
         const completedTasks = tasks.filter(t => t.status === UserTaskStatus.DONE).length;
+        const uncompletedTasks = totalTasks - completedTasks;
+        const averageTaskCompletionRate =
+            totalTasks > 0 ? Math.round((completedTasks / totalTasks) * maxProgress) : 0;
 
-        const subjectProgressMap = new Map<number, number>();
-
+        const subjectMap = new Map<number, number>();
         for (const task of tasks) {
-            const subjectid = task.userSubject.userSubjectId;
-            if (!subjectProgressMap.has(subjectid)) {
-                subjectProgressMap.set(subjectid, task.userSubject.subjectProgress ?? 0);
+            const subjectId = task.userSubject.userSubjectId;
+            if (!subjectMap.has(subjectId)) {
+                subjectMap.set(subjectId, task.userSubject.subjectProgress ?? 0);
             }
         }
 
-        const totalProgress = Array.from(subjectProgressMap.values()).reduce((sum, p) => sum + p, 0);
-        const averageProgress = subjectProgressMap.size > 0
-            ? Math.round(totalProgress / subjectProgressMap.size)
-            : 0;
+        const totalSubjects = subjectMap.size;
+        const completedSubjects = Array.from(subjectMap.values()).filter(prog => prog === maxProgress).length;
+        const uncompletedSubjects = totalSubjects - completedSubjects;
+
+        const totalSubjectProgress = Array.from(subjectMap.values()).reduce((sum, prog) => sum + prog, 0);
+        const averageSubjectProgress =
+            totalSubjects > 0 ? Math.round(totalSubjectProgress / totalSubjects) : 0;
 
         return {
+            totalSubjects,
+            completedSubjects,
+            uncompletedSubjects,
+            averageSubjectProgress,
+
             totalTasks,
             completedTasks,
-            averageProgress,
+            uncompletedTasks,
+            averageTaskCompletionRate,
         };
     }
 
     async getActivityLogs(courseId: number, lang: string, user: User, userId?: number): Promise<ActivityLogDto[]> {
-        const query = this.userTaskRepo
-            .createQueryBuilder('userTask')
-            .leftJoin('userTask.userSubject', 'us')
-            .leftJoin('us.userCourse', 'uc')
-            .leftJoin('uc.course', 'course')
-            .leftJoin('us.subject', 'subject')
-            .leftJoin('userTask.task', 'task')
-            .leftJoin('us.user', 'student')
+        await this.validateAccess(courseId, user, lang);
 
-            .where('course.courseId = :courseId', { courseId });
+        const [courseLogs, subjectLogs, taskLogs] = await Promise.all([
+            this.getCourseLogs(courseId, userId),
+            this.getSubjectLogs(courseId, userId),
+            this.getTaskLogs(courseId, userId),
+        ]);
 
-        if (user.role === Role.SUPERVISOR) {
-            query.innerJoin('course.supervisorCourses', 'sc')
-                .andWhere('sc.supervisor_id = :supervisorId', { supervisorId: user.userId });
-        }
+        const allLogs = [...(courseLogs || []), ...(subjectLogs || []), ...(taskLogs || []),];
 
-        if (userId) {
-            query.andWhere('student.userId = :userId', { userId });
-        }
+        if (allLogs.length === 0) return [];
 
-        const results = await query.select([
-            'userTask.status',
-            'userTask.assignedAt',
-            'userTask.submittedAt',
-            'task.name',
-            'student.fullName',
-            'subject.name',
-        ]).orderBy('userTask.assignedAt', 'DESC').getMany();
-
-        return results.map(user_task => {
-            if (!user_task) {
-                throw new BadRequestException(this.i18nUtils.translate('validation.user_task.user_task_not_found', {}, lang))
-            }
-
-            const taskName = user_task?.task?.name ?? null;
-            const status = user_task?.status as UserTaskStatus;
-            const assignedAt = user_task?.assignedAt;
-            const userName = user_task?.userSubject?.user?.userName ?? null;
-            const subjectName = user_task?.userSubject?.courseSubject?.subject?.name ?? null;
-
-            return { taskName, status, assignedAt, userName, subjectName };
-        });
+        return allLogs.sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime());
     }
 
+    private async validateAccess(courseId: number, user: User, lang: string): Promise<void> {
+        if (user.role === Role.ADMIN) return;
+
+        const isSupervisor = await this.supervisorCourseRepo.exists({
+            where: { course: { courseId }, supervisor: { userId: user.userId } }
+        });
+
+        if (!isSupervisor) {
+            throw new ForbiddenException(this.i18nUtils.translate('validation.auth.access_denied', {}, lang));
+        }
+    }
+
+    private async getCourseLogs(courseId: number, userId?: number): Promise<ActivityLogDto[]> {
+        const userCourseLogs = await this.userCourseRepo
+            .createQueryBuilder('uc')
+            .select([
+                'uc.course_id AS courseId',
+                'uc.user_id AS userId',
+                `'COURSE_REGISTER' AS eventType`,
+                'uc.registration_date AS timestamp',
+                `NULL AS meta`
+            ])
+            .where('uc.course_id = :courseId', { courseId })
+            .andWhere(userId ? 'uc.user_id = :userId' : '1=1', { userId })
+            .getRawMany<ActivityLogDto>();
+
+        const finishedLogs = await this.userCourseRepo
+            .createQueryBuilder('uc')
+            .select([
+                'uc.course_id AS courseId',
+                'uc.user_id AS userId',
+                `'COURSE_FINISH' AS eventType`,
+                'uc.finished_at AS timestamp',
+                `NULL AS meta`
+            ])
+            .where('uc.course_id = :courseId', { courseId })
+            .andWhere('uc.finished_at IS NOT NULL')
+            .andWhere(userId ? 'uc.user_id = :userId' : '1=1', { userId })
+            .getRawMany<ActivityLogDto>();
+
+        return [...userCourseLogs, ...finishedLogs];
+    }
+
+    private async getSubjectLogs(courseId: number, userId?: number): Promise<ActivityLogDto[]> {
+        const query = this.userSubjectRepo
+            .createQueryBuilder('us')
+            .innerJoin('us.courseSubject', 'cs')
+            .select([
+                'cs.course_id AS courseId',
+                'us.user_id AS userId',
+                `'SUBJECT_START' AS eventType`,
+                'us.started_at AS timestamp',
+                'cs.subject_id AS "meta.subjectId"'
+            ])
+            .where('cs.course_id = :courseId', { courseId })
+            .andWhere('us.started_at IS NOT NULL');
+
+        if (userId) query.andWhere('us.user_id = :userId', { userId });
+
+        const startedLogs = await query.getRawMany<ActivityLogDto>();
+
+        const finishedLogs = await this.userSubjectRepo
+            .createQueryBuilder('us')
+            .innerJoin('us.courseSubject', 'cs')
+            .select([
+                'cs.course_id AS courseId',
+                'us.user_id AS userId',
+                `'SUBJECT_FINISH' AS eventType`,
+                'us.finished_at AS timestamp',
+                'cs.subject_id AS "meta.subjectId"'
+            ])
+            .where('cs.course_id = :courseId', { courseId })
+            .andWhere('us.finished_at IS NOT NULL')
+            .andWhere(userId ? 'us.user_id = :userId' : '1=1', { userId })
+            .getRawMany<ActivityLogDto>();
+
+        return [...startedLogs, ...finishedLogs];
+    }
+
+    private async getTaskLogs(courseId: number, userId?: number): Promise<ActivityLogDto[]> {
+        const query = this.userTaskRepo
+            .createQueryBuilder('ut')
+            .innerJoin('ut.userSubject', 'us')
+            .innerJoin('us.courseSubject', 'cs')
+            .select([
+                'cs.course_id AS courseId',
+                'us.user_id AS userId',
+                `'TASK_DONE' AS eventType`,
+                'ut.done_at AS timestamp',
+                'ut.task_id AS "meta.taskId"'
+            ])
+            .where('cs.course_id = :courseId', { courseId })
+            .andWhere('ut.done_at IS NOT NULL');
+
+        if (userId) query.andWhere('us.user_id = :userId', { userId });
+
+        return await query.getRawMany<ActivityLogDto>();
+    }
 }

--- a/src/api/user_course/user_course.controller.ts
+++ b/src/api/user_course/user_course.controller.ts
@@ -9,11 +9,16 @@ import { User } from 'src/database/entities/user.entity';
 import { ApiResponse } from 'src/helper/interface/api.interface';
 import { AssignTraineeToCourseResponseDto } from 'src/helper/interface/course.iterface';
 import { traineeIdDto, userIdDto } from 'src/validation/class_validation/user.validation';
+import { ApiBearerAuth } from '@nestjs/swagger';
+import { ApiResponseRegisterToCourse } from 'src/helper/swagger/user_course/user_course_response.decorator';
+import { ApiResponseGetActiveCourse } from 'src/helper/swagger/user_course/course_active_response.decorator';
 
 @Controller('user_course')
 export class UserCourseController {
     constructor(private readonly userCourseSErvice: UserCourseService) { }
 
+    @ApiResponseRegisterToCourse()
+    @ApiBearerAuth('access-token')
     @AuthRoles(Role.TRAINEE)
     @Post(':courseId/trainee')
     async registerToCourse(@Param() courseId: courseIdDto, @UserDecorator() traineeId: User, @Language() lang: string): Promise<ApiResponse | AssignTraineeToCourseResponseDto> {
@@ -21,6 +26,8 @@ export class UserCourseController {
         return result;
     }
 
+    @ApiResponseGetActiveCourse()
+    @ApiBearerAuth('access-token')
     @AuthRoles(Role.TRAINEE)
     @Get('trainee/:traineeId/courses/active')
     async viewActiveCourse(@Param() traineeId: traineeIdDto, @Language() lang: string) {

--- a/src/database/entities/task.entity.ts
+++ b/src/database/entities/task.entity.ts
@@ -26,7 +26,7 @@ export class Task {
   @UpdateDateColumn({ type: 'timestamp' })
   updatedAt: Date;
 
-  @ManyToOne(() => Subject, (subject) => subject.tasks)
+  @ManyToOne(() => Subject, (subject) => subject.tasks, { onDelete: 'CASCADE' })
   subject: Subject;
 
   @OneToMany(() => UserTask, (ut) => ut.task)

--- a/src/database/entities/user_task.entity.ts
+++ b/src/database/entities/user_task.entity.ts
@@ -25,12 +25,6 @@ export class UserTask {
   status: UserTaskStatus;
 
   @Column({ type: 'datetime', nullable: true })
-  assignedAt?: Date;
-
-  @Column({ type: 'datetime', nullable: true })
-  dueAt?: Date;
-
-  @Column({ type: 'datetime', nullable: true })
   doneAt?: Date;
 }
 

--- a/src/helper/constants/cron_expression.constant.ts
+++ b/src/helper/constants/cron_expression.constant.ts
@@ -13,6 +13,7 @@ export const firstUserSubjectProgress = 0;
 export const course_process_constant = 50;
 export const maxProgress = 100;
 export const endDateOfCourse = 2;
+export const millisecondsPerDay = 24 * 60 * 60 * 1000;
 export const formatDateConstant = 'dd/MM/yyyy';
 export const subjectDailySummary = '[Báo cáo tổng hợp] Hoạt động học viên trong ngày';
 export const subjectCourseReminder = `[Nhắc nhở] Khóa học sắp kết thúc`;

--- a/src/helper/interface/reporting.interface.ts
+++ b/src/helper/interface/reporting.interface.ts
@@ -1,17 +1,35 @@
 import { UserTaskStatus } from "src/database/dto/user_task.dto";
 
 export class ReportResponseDto {
+    totalSubjects: number;
+    completedSubjects: number;
+    uncompletedSubjects: number;
+    averageSubjectProgress: number;
+
     totalTasks: number;
     completedTasks: number;
-    averageProgress: number;
+    uncompletedTasks: number;
+    averageTaskCompletionRate: number;
 }
 
-export class ActivityLogDto {
-    taskName: string;
-    subjectName: string;
-    status: UserTaskStatus;
-    assignedAt: Date | undefined;
-    userName: string;
+export interface ActivityLogDto {
+    courseId: number;
+    userId: number;
+    eventType: ActivityEventType;
+    timestamp: string;
+    meta?: {
+        subjectId?: number;
+        taskId?: number;
+        courseId?: number;
+    };
+}
+
+export interface ActivityEventType {
+    COURSE_REGISTER : 'COURSE_REGISTER',
+    COURSE_FINISH : 'COURSE_FINISH',
+    SUBJECT_START : 'SUBJECT_START',
+    SUBJECT_FINISH : 'SUBJECT_FINISH',
+    TASK_DONE : 'TASK_DONE',
 }
 
 export interface MailJobData {

--- a/src/helper/interface/user_task.interface.ts
+++ b/src/helper/interface/user_task.interface.ts
@@ -1,8 +1,15 @@
 export class TrainingCalendarDto {
-    courseName: string;
-    subjectName: string;
-    taskName: string;
-    status: string;
-    assignedAt: string | null;
-    dueAt: string | null;
+  courseName: string;
+  subjectName: string;
+  taskName: string;
+  startAt: string;
+  endAt: string;
+  type: 'subject' | 'task';
+  status?: string;
 }
+
+export interface ViewTaskDto {
+  name: string;
+  fileUrl: string;
+}
+

--- a/src/helper/swagger/user_course/course_active_response.decorator.ts
+++ b/src/helper/swagger/user_course/course_active_response.decorator.ts
@@ -1,0 +1,41 @@
+import { applyDecorators } from "@nestjs/common";
+import { ApiOperation, ApiParam, ApiResponse } from "@nestjs/swagger";
+import { ErrorResponseDto } from "src/validation/api_document/error/error.validation";
+import { ServerErrorResponseDto } from "src/validation/api_document/error/server_error.validation";
+import { getCourseActiveSuccessResponseDto } from "src/validation/api_document/user_course/success_user_course";
+
+export function ApiResponseGetActiveCourse() {
+    return applyDecorators(
+        ApiOperation({
+            summary: "Xem khóa học đang tham gia của học viên (View Active Course)",
+            description: "Cho phép người dùng xem được thông tin chi tiết khoá học đang hoạt động của mình."
+        }),
+
+        ApiParam({
+            name: 'traineeId',
+            description: "Nhập id người dùng",
+            type: Number,
+            example: 14,
+            required: true
+        }),
+
+        ApiResponse({
+            status: 200,
+            description: 'Thành công',
+            type: getCourseActiveSuccessResponseDto
+        }),
+
+        ApiResponse({
+            status: 400,
+            description:
+                'Lỗi xác thực. Các lỗi khác cũng trả về định dạng giống, chỉ thay đổi `status`, `message`, `code`, `path`',
+            type: ErrorResponseDto,
+        }),
+
+        ApiResponse({
+            status: 500,
+            description: 'Lỗi hệ thống, có thể do server hoặc cơ sở dữ liệu',
+            type: ServerErrorResponseDto,
+        }),
+    )
+}

--- a/src/helper/swagger/user_course/user_course_response.decorator.ts
+++ b/src/helper/swagger/user_course/user_course_response.decorator.ts
@@ -1,0 +1,45 @@
+import { applyDecorators } from "@nestjs/common";
+import { ApiOperation, ApiParam, ApiResponse } from "@nestjs/swagger";
+import { ErrorResponseDto } from "src/validation/api_document/error/error.validation";
+import { ServerErrorResponseDto } from "src/validation/api_document/error/server_error.validation";
+import { registerToCourseSuccessResponseDto } from "src/validation/api_document/user_course/success_user_course";
+
+export function ApiResponseRegisterToCourse() {
+    return applyDecorators(
+        ApiOperation({
+            summary: "Học viên gia nhập khóa học (Trainee joins Course)",
+            description: `* Điều kiện để đăng ký khoá học: \n
+            - Người dùng chưa đăng ký khoá học đang chọn. \n
+            - Chưa đăng ký khoá học nào đã bắt đầu ( Mỗi người dùng chỉ được tham gia vào 1 khoá học đã bắt đầu).\n
+            - Khi người dùng đăng ký thành công vào khoá học được chọn, hệ thống sẽ tạo mới 1 bản ghi vào bảng user_course với trạng thái đăng ký.\n
+            - Đồng thời sẽ nhận được email đăng ký thành công khoá học.`
+        }),
+
+        ApiParam({
+            name: 'courseId',
+            description: "Nhập id khoá học muốn đăng ký",
+            type: Number,
+            example: 14,
+            required: true
+        }),
+
+        ApiResponse({
+            status: 200,
+            description: 'Thành công',
+            type: registerToCourseSuccessResponseDto
+        }),
+
+        ApiResponse({
+            status: 400,
+            description:
+                'Lỗi xác thực. Các lỗi khác cũng trả về định dạng giống, chỉ thay đổi `status`, `message`, `code`, `path`',
+            type: ErrorResponseDto,
+        }),
+
+        ApiResponse({
+            status: 500,
+            description: 'Lỗi hệ thống, có thể do server hoặc cơ sở dữ liệu',
+            type: ServerErrorResponseDto,
+        }),
+    )
+}

--- a/src/helper/swagger/user_task/complete_task.decorator.ts
+++ b/src/helper/swagger/user_task/complete_task.decorator.ts
@@ -1,0 +1,41 @@
+import { applyDecorators } from "@nestjs/common";
+import { ApiOperation, ApiParam, ApiResponse } from "@nestjs/swagger";
+import { ErrorResponseDto } from "src/validation/api_document/error/error.validation";
+import { ServerErrorResponseDto } from "src/validation/api_document/error/server_error.validation";
+import { CompleteTaskSuccessDto } from "src/validation/api_document/user_task/success_user_task";
+
+export function ApiResponseCompleteTask() {
+    return applyDecorators(
+        ApiOperation({
+            summary: "Báo cáo hoàn thành 1 nhiệm vụ",
+            description: "Báo cáo khi người dùng hoàn thành 1 nhiệm vụ (Hoàn thành 1 nhiệm vụ trong bài học), Khi hoàn thành tất cả các nhiệm vụ thì khoá học đó sẽ tự đồng hoàn thành,"
+        }),
+
+        ApiParam({
+            name: 'taskId',
+            description: "Nhập id nhiệm vụ muốn hoàn thành",
+            type: Number,
+            example: 4,
+            required: true
+        }),
+
+        ApiResponse({
+            status: 200,
+            description: 'Thành công',
+            type: CompleteTaskSuccessDto
+        }),
+
+        ApiResponse({
+            status: 400,
+            description:
+                'Lỗi xác thực. Các lỗi khác cũng trả về định dạng giống, chỉ thay đổi `status`, `message`, `code`, `path`',
+            type: ErrorResponseDto,
+        }),
+
+        ApiResponse({
+            status: 500,
+            description: 'Lỗi hệ thống, có thể do server hoặc cơ sở dữ liệu',
+            type: ServerErrorResponseDto,
+        }),
+    )
+}

--- a/src/helper/swagger/user_task/get_training_calendar.decorator.ts
+++ b/src/helper/swagger/user_task/get_training_calendar.decorator.ts
@@ -1,0 +1,33 @@
+import { applyDecorators } from "@nestjs/common";
+import { ApiOperation, ApiResponse } from "@nestjs/swagger";
+import { ErrorResponseDto } from "src/validation/api_document/error/error.validation";
+import { ServerErrorResponseDto } from "src/validation/api_document/error/server_error.validation";
+import { GetTrainingCalendarSuccessDto } from "src/validation/api_document/user_task/success_user_task";
+
+export function ApiResponseGetTraingCelendar() {
+    return applyDecorators(
+        ApiOperation({
+            summary: "Tạo lịch học tự động cho người dùng cho từng task",
+            description: "Tạo lịch học cho trainee bằng cách lập lịch động cho từng task dựa vào startedAt và finishedAt trong bảng user_subject và studyDuration trong bảng subject"
+        }),
+
+        ApiResponse({
+            status: 200,
+            description: 'Thành công',
+            type: GetTrainingCalendarSuccessDto
+        }),
+
+        ApiResponse({
+            status: 400,
+            description:
+                'Lỗi xác thực. Các lỗi khác cũng trả về định dạng giống, chỉ thay đổi `status`, `message`, `code`, `path`',
+            type: ErrorResponseDto,
+        }),
+
+        ApiResponse({
+            status: 500,
+            description: 'Lỗi hệ thống, có thể do server hoặc cơ sở dữ liệu',
+            type: ServerErrorResponseDto,
+        }),
+    )
+}

--- a/src/helper/swagger/user_task/view_task.decorator.ts
+++ b/src/helper/swagger/user_task/view_task.decorator.ts
@@ -1,0 +1,33 @@
+import { applyDecorators } from "@nestjs/common";
+import { ApiOperation, ApiResponse } from "@nestjs/swagger";
+import { ErrorResponseDto } from "src/validation/api_document/error/error.validation";
+import { ServerErrorResponseDto } from "src/validation/api_document/error/server_error.validation";
+import { ViewTaskSuccessDto } from "src/validation/api_document/user_task/success_user_task";
+
+export function ApiResponseViewTask() {
+    return applyDecorators(
+        ApiOperation({
+            summary: "Xem thông tin bài học",
+            description: "Cho phép người dùng xem thông tin chi tiết bài học đã chọn"
+        }),
+
+        ApiResponse({
+            status: 200,
+            description: 'Thành công',
+            type: ViewTaskSuccessDto
+        }),
+
+        ApiResponse({
+            status: 400,
+            description:
+                'Lỗi xác thực. Các lỗi khác cũng trả về định dạng giống, chỉ thay đổi `status`, `message`, `code`, `path`',
+            type: ErrorResponseDto,
+        }),
+
+        ApiResponse({
+            status: 500,
+            description: 'Lỗi hệ thống, có thể do server hoặc cơ sở dữ liệu',
+            type: ServerErrorResponseDto,
+        }),
+    )
+}

--- a/src/i18n/en/validation.json
+++ b/src/i18n/en/validation.json
@@ -179,6 +179,7 @@
   },
   "user_course": {
     "course_not_active": "No active courses available",
+    "user_already_registered_course": "User has already registered for this course",
     "courseId": {
       "isInt": "course_id must be an integer",
       "isNotEmpty": "course_id cannot be empty"
@@ -233,6 +234,7 @@
     "user_task_not_found_date": "No data available for the task",
     "user_task_not_found": "Corresponding task not found",
     "complete_task_success": "Mission successful report",
+    "complete_task_faild": "Mission failed report",
     "userSubjectId": {
       "isInt": "user_subject_id must be an integer",
       "isNotEmpty": "user_subject_id cannot be empty"

--- a/src/i18n/vi/validation.json
+++ b/src/i18n/vi/validation.json
@@ -183,6 +183,7 @@
   },
   "user_course": {
     "course_not_active": "Không có khoá học nào đang hoạt động",
+    "user_already_registered_course": "Người dùng đã đăng ký khoá học này",
     "courseId": {
       "isInt": "course_id phải là số nguyên",
       "isNotEmpty": "course_id không được để trống"
@@ -237,6 +238,7 @@
     "user_task_not_found_date": "Không có dữ liệu cho nhiệm vụ",
     "user_task_not_found": "Không tìm thấy nhiệm vụ tương ứng",
     "complete_task_success": "Báo cáo nhiệm vụ thành công",
+    "complete_task_faild": "Báo cáo nhiệm vụ không thành công",
     "userSubjectId": {
       "isInt": "user_subject_id phải là số nguyên",
       "isNotEmpty": "user_subject_id không được để trống"

--- a/src/validation/api_document/user_course/success_user_course.ts
+++ b/src/validation/api_document/user_course/success_user_course.ts
@@ -1,0 +1,61 @@
+import { ApiProperty } from "@nestjs/swagger";
+
+export class registerToCourseSuccessResponseDto {
+    @ApiProperty({ example: 200 })
+    code: string;
+
+    @ApiProperty({ example: true })
+    success: boolean;
+
+    @ApiProperty({ example: "Thành công" })
+    message: string;
+
+    @ApiProperty({
+        example: {
+            userCourseId: 34,
+            userName: "trainee nè",
+            courseName: "Khoá học Golang",
+            registrationDate: "2025-08-06",
+            courseProgress: 0,
+            status: "RESIGN"
+        }
+    })
+    data: {
+        userCourseId: number,
+        userName: string,
+        courseName: string,
+        registrationDate: string,
+        courseProgress: number,
+        status: string
+    }
+}
+
+export class getCourseActiveSuccessResponseDto {
+    @ApiProperty({ example: 200 })
+    code: string;
+
+    @ApiProperty({ example: true })
+    success: boolean;
+
+    @ApiProperty({ example: "Thành công" })
+    message: string;
+
+    @ApiProperty({
+        example: {
+            course_id: 3,
+            name: "Khoá học Golang",
+            description: "Khoá học gồm các bài hướng dẫn học Golang",
+            start: "2025-08-09T17:00:00.000Z",
+            end: "2025-09-09T17:00:00.000Z",
+            status: "ACTIVE"
+        }
+    })
+    data: {
+        course_id: number,
+        name: string,
+        description: string,
+        start: string,
+        end: string,
+        status: string
+    }
+}

--- a/src/validation/api_document/user_task/success_user_task.ts
+++ b/src/validation/api_document/user_task/success_user_task.ts
@@ -1,0 +1,76 @@
+import { ApiProperty } from "@nestjs/swagger";
+
+export class GetTrainingCalendarSuccessDto {
+    @ApiProperty({ example: 200 })
+    code: number;
+
+    @ApiProperty({ example: true })
+    success: boolean;
+
+    @ApiProperty({ example: "Thành công" })
+    message: string;
+
+    @ApiProperty({
+        example: [
+            {
+                courseName: "Khóa học Nodejs",
+                subjectName: "Toán học",
+                taskName: "Bài tập Toán 1",
+                startAt: "2025-08-01T01:00:00.000Z",
+                endAt: "2025-08-16T01:00:00.000Z",
+                type: "task"
+            },
+            {
+                courseName: "Khóa học Nodejs",
+                subjectName: "Toán học",
+                taskName: "Bài tập Toán 2",
+                startAt: "2025-08-16T01:00:00.000Z",
+                endAt: "2025-08-31T01:00:00.000Z",
+                type: "task"
+            }
+        ]
+    })
+    data: {
+        courseName: "Khóa học Nodejs",
+        subjectName: "Toán học",
+        taskName: "Bài tập Toán 2",
+        startAt: "2025-08-16T01:00:00.000Z",
+        endAt: "2025-08-31T01:00:00.000Z",
+        type: "task"
+    }
+}
+
+export class CompleteTaskSuccessDto {
+    @ApiProperty({ example: 200 })
+    code: number;
+
+    @ApiProperty({ example: true })
+    success: boolean;
+
+    @ApiProperty({ example: "Báo cáo nhiệm vụ thành công" })
+    message: string;
+}
+
+export class ViewTaskSuccessDto {
+    @ApiProperty({ example: 200 })
+    code: number;
+
+    @ApiProperty({ example: true })
+    success: boolean;
+
+    @ApiProperty({ example: "Thành công" })
+    message: string;
+
+    @ApiProperty({
+        example: [
+            {
+                t_name: "Bài tập Toán 1",
+                file_url: "https://example.com/task1.pdf"
+            }
+        ]
+    })
+    data: {
+        t_name: "Bài tập Toán 1",
+        file_url: "https://example.com/task1.pdf"
+    }
+}

--- a/src/validation/class_validation/user_task.validation.ts
+++ b/src/validation/class_validation/user_task.validation.ts
@@ -22,14 +22,6 @@ export class UserTaskDto {
     status: UserTaskStatus;
 
     @Type(() => Date)
-    @IsDate(i18nValidationMessage('validation.user_task.assignedAt.isDate'))
-    assignedAt?: Date;
-
-    @Type(() => Date)
-    @IsDate(i18nValidationMessage('validation.user_task.dueAt.isDate'))
-    dueAt?: Date;
-
-    @Type(() => Date)
     @IsDate(i18nValidationMessage('validation.user_task.doneAt.isDate'))
     doneAt?: Date;
 }


### PR DESCRIPTION
Chức năng: Viết tài liệu (document) Swagger cho các API trong User và Course

**Nội dung thay đổi: Thêm các decorator Swagger cho các endpoint** 
- người dùng đăng ký khoá học (/user_course/ciurseId/trainee),
- Xem khoá học đang hoạt động (user_course/trainee/:traineeId/course/active),
- Tạo lịch học tự động cho người dùng mỗi task (user_task/calendar),
- Báo cáo hoàn thành 1 nhiệm vụ (/user_task/tasks/:taskId/complete)
- Xem thông tin bài học (/user_task/:taskId)

Chuẩn hóa tài liệu API cho module xác thực, giúp các developer dễ dàng hiểu và sử dụng các endpoint.
Hỗ trợ tự động sinh tài liệu Swagger UI, phục vụ kiểm thử và tích hợp hệ thống.

**Thay đổi logic để phù hợp cho 1 số chức năng:** 
- Tạo lịch đào tạo (Training Calendar): getTrainingCalendar 
- Báo cáo tiến độ (Report Task Completion). completeTask
- Xem báo cáo hàng ngày/ tháng (Daily/Monthly Reports) getReport
- Xem lịch sử hoạt động của cả khóa/học viên (Course Activity Logs): getActivityLogs
