### PR TITLE
TraineeController_unit_test_nest_di

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,10 +98,16 @@
       "json",
       "ts"
     ],
-    "rootDir": "src",
+    "roots": [
+      "<rootDir>/src",
+      "<rootDir>/test"
+    ],
     "testRegex": ".*\\.spec\\.ts$",
     "transform": {
       "^.+\\.(t|j)s$": "ts-jest"
+    },
+    "moduleNameMapper": {
+      "^src/(.*)$": "<rootDir>/src/$1"
     },
     "collectCoverageFrom": [
       "**/*.(t|j)s"

--- a/src/api/user/trainee/trainee.controller.ts
+++ b/src/api/user/trainee/trainee.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Delete, Get, Param, Post, Put } from '@nestjs/common';
+import { Body, Controller, Delete, Get, Param, Post, Put, Query } from '@nestjs/common';
 import { TraineeService } from './trainee.service';
 import { CreateUserDto, UpdateUserDto, userIdDto } from 'src/validation/class_validation/user.validation';
 import { Language } from 'src/helper/decorators/language.decorator';
@@ -15,8 +15,8 @@ export class TraineeController {
 
     @AuthRoles(Role.ADMIN,Role.SUPERVISOR)
     @Get()
-    async getAll (@Language() lang: string) {
-        const result = await this.traineeService.getAll(lang);
+    async getAll (@Language() lang: string, @Query() query: { page?: number, pageSize?: number }) {
+        const result = await this.traineeService.getAll(lang, query.page, query.pageSize);
         return result;
     }
 

--- a/src/api/user/trainee/trainee.module.ts
+++ b/src/api/user/trainee/trainee.module.ts
@@ -7,10 +7,11 @@ import { I18nUtils } from 'src/helper/utils/i18n-utils';
 import { hashPassword } from 'src/helper/shared/hash_password.shared';
 import { UserSubject } from 'src/database/entities/user_subject.entity';
 import { UserCourse } from 'src/database/entities/user_course.entity';
+import { PaginationService } from 'src/helper/shared/pagination.shared';
 
 @Module({
   imports: [TypeOrmModule.forFeature([User,UserSubject,UserCourse])],
   controllers: [TraineeController],
-  providers: [TraineeService,I18nUtils,hashPassword]
+  providers: [TraineeService,I18nUtils,hashPassword, PaginationService]
 })
 export class TraineeModule {}

--- a/test/user/trainee/constants/error.constant.ts
+++ b/test/user/trainee/constants/error.constant.ts
@@ -1,0 +1,15 @@
+import { BadRequestException, NotFoundException, ConflictException, InternalServerErrorException } from '@nestjs/common';
+
+export const missingRequiredFieldsError = new BadRequestException('Missing required fields');
+export const userNotFoundError = new NotFoundException('User not found');
+export const updateFailedError = new InternalServerErrorException('Update failed');
+export const emailExistsError = new ConflictException('Email already exists');
+export const deleteNotAllowedError = new BadRequestException('Delete not allowed');
+export const deleteFailedError = new InternalServerErrorException('Delete failed');
+export const createFailedError = new InternalServerErrorException('Create failed');
+export const noTraineeError = new NotFoundException('No trainee found');
+export const traineeNotFoundError = new NotFoundException('Trainee not found');
+export const noTraineeIdError = new BadRequestException('No trainee id found');
+export const noTraineeEmailError = new BadRequestException('No trainee email found');
+export const databaseConnectionLostError = new InternalServerErrorException('Database connection lost');
+export const noTraineesError = new NotFoundException('No trainees');

--- a/test/user/trainee/constants/trainee_test.constant.ts
+++ b/test/user/trainee/constants/trainee_test.constant.ts
@@ -1,0 +1,5 @@
+import { UpdateUserDto, userIdDto } from "src/validation/class_validation/user.validation";
+
+export const traineeId: userIdDto = { userId: 1 };
+export const updateDto: UpdateUserDto = { userName: 'updateduser' };
+export const updateDtoEmail: UpdateUserDto = { email: 'test@example.com' };

--- a/test/user/trainee/dto/test_helpers.ts
+++ b/test/user/trainee/dto/test_helpers.ts
@@ -1,0 +1,40 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { Type } from '@nestjs/common';
+import { I18nUtils } from 'src/helper/utils/i18n-utils';
+import { RolesGuard } from 'src/middleware/decentralization.middleware';
+import { ModuleOpts } from '../interface/trainee_test.interface';
+
+export function createMockService<T extends object>(methods: (keyof T)[]): jest.Mocked<T> {
+  const mock = {} as Record<keyof T, jest.Mock>;
+  methods.forEach((method) => {
+    mock[method] = jest.fn();
+  }); 
+  return mock as unknown as jest.Mocked<T>;
+}
+
+export async function buildTestingModule<C, S extends object>(opts: ModuleOpts<C, S>): Promise<{ controller: C; serviceMock: jest.Mocked<S> }> {
+  const serviceMock = createMockService<S>(opts.serviceMethods);
+
+  const moduleRef: TestingModule = await Test.createTestingModule({
+    controllers: [opts.controller],
+    providers: [
+      { provide: opts.service, useValue: serviceMock },
+      { provide: I18nUtils, useValue: { t: jest.fn((key: string) => key) } },
+    ],
+  })
+    .overrideGuard(RolesGuard)
+    .useValue({ canActivate: () => true })
+    .compile();
+
+  return {
+    controller: moduleRef.get<C>(opts.controller),
+    serviceMock,
+  };
+}
+
+export const expectPagination = (
+  res: { data?: { meta: unknown } },
+  meta: unknown,
+): void => {
+  expect(res.data?.meta).toEqual(meta);
+};

--- a/test/user/trainee/dto/trainee.fixture.ts
+++ b/test/user/trainee/dto/trainee.fixture.ts
@@ -1,0 +1,29 @@
+import { traineeResponse } from "../response/trainee.response";
+
+export const LANG = 'en';
+export const PAGINATION = { page: 1, pageSize: 10 } as const;
+export const INVALID_PAGINATION = { page: -1, pageSize: 0 } as const;
+export const INVALID_PAGINATION2 = { page: 10000, pageSize: 10000 } as const;
+export const TRAINEE_ITEM = traineeResponse.data;
+export const META = {
+    totalItems: 1,
+    itemCount: 1,
+    currentPage: 1,
+    itemsPerPage: PAGINATION.pageSize,
+    totalPages: 1,
+} as const;
+
+export const SUCCESS_GET_ALL = {
+    success: true,
+    message: '',
+    data: {
+        items: [TRAINEE_ITEM],
+        meta: META,
+    },
+} as const;
+
+export const EXPECTED_RESULT = {
+    success: true,
+    message: '',
+    data: TRAINEE_ITEM,
+} as const;

--- a/test/user/trainee/interface/trainee_test.interface.ts
+++ b/test/user/trainee/interface/trainee_test.interface.ts
@@ -1,0 +1,7 @@
+import { Type } from "@nestjs/common";
+
+export interface ModuleOpts<C, S extends object> {
+  controller: Type<C>;
+  service: Type<S>;
+  serviceMethods: (keyof S)[];
+}

--- a/test/user/trainee/response/trainee.response.ts
+++ b/test/user/trainee/response/trainee.response.ts
@@ -1,0 +1,41 @@
+import { Role, UserStatus } from "src/database/dto/user.dto";
+
+export const traineeResponse = {
+    success: true,
+    message: '',
+    data: {
+        userId: Number,
+        userName: String,
+        email: String,
+        role: Role.TRAINEE,
+        status: UserStatus.ACTIVE,
+    },
+}
+
+export const traineeCreateResponse = {
+    success: true,
+    message: '',
+    data: {
+        userId: 1,
+        email: 'test@example.com',
+        userName: 'testuser',
+        password: 'Password123!',
+        role: Role.TRAINEE,
+        status: UserStatus.ACTIVE,
+    }
+};
+
+export const traineeUpdateResponse = {
+    success: true,
+    message: '',
+    data: {
+        userId: 1,
+        userName: 'updateduser',
+        email: 'test@example.com',
+        role: Role.TRAINEE,
+        status: UserStatus.ACTIVE,
+    }
+};
+
+export const traineeDeleteResponse = { success: true, message: '' };
+

--- a/test/user/trainee/trainee.di.spec.ts
+++ b/test/user/trainee/trainee.di.spec.ts
@@ -1,0 +1,216 @@
+import { TraineeController } from '../../../src/api/user/trainee/trainee.controller';
+import { TraineeService } from '../../../src/api/user/trainee/trainee.service';
+import { userIdDto } from '../../../src/validation/class_validation/user.validation';
+import { NotFoundException } from '@nestjs/common';
+import * as F from './dto/trainee.fixture';
+import { traineeId, updateDto, updateDtoEmail } from './constants/trainee_test.constant';
+import { emailExistsError, createFailedError, missingRequiredFieldsError, userNotFoundError, updateFailedError, deleteNotAllowedError, deleteFailedError, databaseConnectionLostError } from './constants/error.constant';
+import { traineeCreateResponse, traineeUpdateResponse, traineeDeleteResponse, traineeResponse } from './response/trainee.response';
+import { buildTestingModule, expectPagination } from './dto/test_helpers';
+
+describe('TraineeController [DI]', () => {
+    let traineeController: TraineeController;
+    let mockTraineeService: jest.Mocked<TraineeService>;
+
+    beforeEach(async () => {
+        const built = await buildTestingModule({
+            controller: TraineeController,
+            service: TraineeService,
+            serviceMethods: ['getAll', 'getById', 'create', 'update', 'delete'],
+        });
+        traineeController = built.controller;
+        mockTraineeService = built.serviceMock;
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    describe('getAll', () => {
+        it('should return an array of trainees', async () => {
+
+            const expectedResult = F.SUCCESS_GET_ALL;
+            mockTraineeService.getAll.mockResolvedValue(expectedResult);
+
+            const result = await traineeController.getAll(F.LANG, F.PAGINATION);
+            expect(result).toEqual(expectedResult);
+            expect(result.data.items).toEqual(expectedResult.data.items);
+            expect(Array.isArray(result.data.items)).toBe(true);
+            expect(result.data.items[0]).toMatchObject(expectedResult.data.items[0]);
+            expectPagination(result, F.META);
+            expect(mockTraineeService.getAll).toHaveBeenCalledWith(F.LANG, 1, 10);
+        });
+
+        it('should throw an error if service fails', async () => {
+            const error = new NotFoundException('No trainees found');
+            mockTraineeService.getAll.mockRejectedValue(error);
+            await expect(traineeController.getAll(F.LANG, F.PAGINATION)).rejects.toThrow(error);
+        });
+
+        it('should propagate unexpected errors', async () => {
+            const err = databaseConnectionLostError;
+            mockTraineeService.getAll.mockRejectedValue(err);
+            await expect(traineeController.getAll(F.LANG, F.PAGINATION)).rejects.toThrow(err);
+        });
+
+        it('should throw BadRequestException for invalid pagination', async () => {
+            mockTraineeService.getAll.mockRejectedValue(missingRequiredFieldsError);
+            await expect(traineeController.getAll(F.LANG, F.INVALID_PAGINATION)).rejects.toThrow(missingRequiredFieldsError);
+            await expect(traineeController.getAll(F.LANG, F.INVALID_PAGINATION2)).rejects.toThrow(missingRequiredFieldsError);
+        });
+
+        it('should throw BadRequestException for invalid language', async () => {
+            mockTraineeService.getAll.mockRejectedValue(missingRequiredFieldsError);
+            await expect(traineeController.getAll(null as unknown as string, F.PAGINATION)).rejects.toThrow(missingRequiredFieldsError);
+            await expect(traineeController.getAll('jp' as unknown as string, F.PAGINATION)).rejects.toThrow(missingRequiredFieldsError);
+        });
+    });
+
+    describe('getById', () => {
+        it('should return a single trainee', async () => {
+            const expectedResult = F.EXPECTED_RESULT;
+            mockTraineeService.getById.mockResolvedValue(expectedResult);
+            const result = await traineeController.getById(traineeId, F.LANG);
+            expect(result).toEqual(expectedResult);
+            expect(result).toMatchObject(traineeResponse);
+            expect(mockTraineeService.getById).toHaveBeenCalledWith(traineeId.userId, F.LANG);
+        });
+
+        it('should throw NotFoundException if trainee not found', async () => {
+
+            const traineeId: userIdDto = { userId: 999 };
+            const error = new NotFoundException('Trainee not found');
+            mockTraineeService.getById.mockRejectedValue(error);
+            await expect(traineeController.getById(traineeId, F.LANG)).rejects.toThrow(error);
+        });
+
+        it('should propagate unexpected errors', async () => {
+            const err = databaseConnectionLostError;
+            mockTraineeService.getById.mockRejectedValue(err);
+            await expect(traineeController.getById(traineeId, F.LANG)).rejects.toThrow(err);
+        });
+
+        it('should throw BadRequestException for invalid language', async () => {
+            mockTraineeService.getById.mockRejectedValue(missingRequiredFieldsError);
+            await expect(traineeController.getById(traineeId, null as unknown as string)).rejects.toThrow(missingRequiredFieldsError);
+            await expect(traineeController.getById(traineeId, 'jp' as unknown as string)).rejects.toThrow(missingRequiredFieldsError);
+        });
+
+        it('should throw error for invalid userId', async () => {
+            const invalidId = { userId: 'invalid' } as unknown as userIdDto;
+            mockTraineeService.getById.mockRejectedValue(userNotFoundError);
+            await expect(traineeController.getById(invalidId, F.LANG)).rejects.toThrow(userNotFoundError);
+        });
+    });
+
+    describe('create', () => {
+        it('should create a new trainee', async () => {
+
+            mockTraineeService.create.mockResolvedValue(traineeCreateResponse);
+            const result = await traineeController.create(traineeCreateResponse.data, F.LANG);
+            expect(result).toEqual(traineeCreateResponse);
+            expect(mockTraineeService.create).toHaveBeenCalledWith(traineeCreateResponse.data, F.LANG);
+
+            expect(result.data).toMatchObject(traineeCreateResponse.data);
+            expect(result.success).toEqual(traineeCreateResponse.success);
+        });
+
+        it('should throw BadRequestException if email exists', async () => {
+            mockTraineeService.create.mockRejectedValue(emailExistsError);
+            await expect(traineeController.create(traineeCreateResponse.data, F.LANG)).rejects.toThrow(emailExistsError);
+        });
+
+        it('should propagate unexpected errors', async () => {
+            mockTraineeService.create.mockRejectedValue(createFailedError);
+            await expect(traineeController.create(traineeCreateResponse.data, F.LANG)).rejects.toThrow(createFailedError);
+        });
+
+        it('should throw BadRequestException for invalid DTO', async () => {
+            const invalidDto = { userName: 'onlyName' } as any;
+            mockTraineeService.create.mockRejectedValue(missingRequiredFieldsError);
+            await expect(traineeController.create(invalidDto, F.LANG)).rejects.toThrow(missingRequiredFieldsError);
+        });
+
+        it('should throw BadRequestException for invalid language', async () => {
+            mockTraineeService.create.mockRejectedValue(missingRequiredFieldsError);
+            await expect(traineeController.create(traineeCreateResponse.data, null as unknown as string)).rejects.toThrow(missingRequiredFieldsError);
+            await expect(traineeController.create(traineeCreateResponse.data, 'jp' as unknown as string)).rejects.toThrow(missingRequiredFieldsError);
+        });
+    });
+
+    describe('update', () => {
+        it('should update a trainee', async () => {
+
+            mockTraineeService.update.mockResolvedValue(traineeUpdateResponse);
+            const result = await traineeController.update(traineeId, updateDto, F.LANG);
+            expect(result).toEqual(traineeUpdateResponse);
+            expect(mockTraineeService.update).toHaveBeenCalledWith(traineeId.userId, updateDto, F.LANG);
+            expect(result.data).toMatchObject(traineeUpdateResponse.data);
+            expect(result.success).toEqual(traineeUpdateResponse.success);
+        });
+
+        it('should throw BadRequestException for empty body', async () => {
+            mockTraineeService.update.mockRejectedValue(missingRequiredFieldsError);
+            await expect(traineeController.update(traineeId, {}, F.LANG)).rejects.toThrow(missingRequiredFieldsError);
+        });
+
+        it('should throw NotFoundException if id not found', async () => {
+            mockTraineeService.update.mockRejectedValue(userNotFoundError);
+            await expect(traineeController.update({ userId: 999 }, updateDto, F.LANG)).rejects.toThrow(userNotFoundError);
+        });
+
+        it('should throw error for invalid id', async () => {
+            const invalidId = { userId: 'invalid' } as unknown as userIdDto;
+            mockTraineeService.update.mockRejectedValue(userNotFoundError);
+            await expect(traineeController.update(invalidId, updateDto, F.LANG)).rejects.toThrow(userNotFoundError);
+        });
+
+        it('should throw BadRequestException when email already exists', async () => {
+            mockTraineeService.update.mockRejectedValue(emailExistsError);
+            await expect(traineeController.update(traineeId, updateDtoEmail, F.LANG)).rejects.toThrow(emailExistsError);
+        });
+
+        it('should throw BadRequestException for invalid language', async () => {
+            mockTraineeService.update.mockRejectedValue(missingRequiredFieldsError);
+            await expect(traineeController.update(traineeId, updateDto, null as unknown as string)).rejects.toThrow(missingRequiredFieldsError);
+            await expect(traineeController.update(traineeId, updateDto, 'jp' as unknown as string)).rejects.toThrow(missingRequiredFieldsError);
+        });
+
+        it('should propagate unexpected errors', async () => {
+            mockTraineeService.update.mockRejectedValue(updateFailedError);
+            await expect(traineeController.update(traineeId, updateDto, F.LANG)).rejects.toThrow(updateFailedError);
+        });
+    });
+
+    describe('delete', () => {
+        it('should delete a trainee', async () => {
+            mockTraineeService.delete.mockResolvedValue(traineeDeleteResponse);
+            const result = await traineeController.delete(traineeId, F.LANG);
+            expect(result).toEqual(traineeDeleteResponse);
+            expect(mockTraineeService.delete).toHaveBeenCalledWith(traineeId.userId, F.LANG);
+            expect(result).toMatchObject(traineeDeleteResponse);
+        });
+
+        it('should throw NotFoundException if id not found', async () => {
+            mockTraineeService.delete.mockRejectedValue(deleteNotAllowedError);
+            await expect(traineeController.delete({ userId: 999 }, F.LANG)).rejects.toThrow(deleteNotAllowedError);
+        });
+
+        it('should throw error for invalid id', async () => {
+            const invalidId = { userId: 'invalid' } as unknown as userIdDto;
+            mockTraineeService.delete.mockRejectedValue(deleteNotAllowedError);
+            await expect(traineeController.delete(invalidId, F.LANG)).rejects.toThrow(deleteNotAllowedError);
+        });
+
+        it('should throw BadRequestException for invalid language', async () => {
+            mockTraineeService.delete.mockRejectedValue(missingRequiredFieldsError);
+            await expect(traineeController.delete(traineeId, null as unknown as string)).rejects.toThrow(missingRequiredFieldsError);
+            await expect(traineeController.delete(traineeId, 'jp' as unknown as string)).rejects.toThrow(missingRequiredFieldsError);
+        });
+
+        it('should propagate unexpected errors', async () => {
+            mockTraineeService.delete.mockRejectedValue(deleteFailedError);
+            await expect(traineeController.delete(traineeId, F.LANG)).rejects.toThrow(deleteFailedError);
+        });
+    });
+});


### PR DESCRIPTION
**Thêm unit test cho TraineeController với NestJS DI**

Mô tả PR:
- Thêm unit test cho TraineeController sử dụng Dependency Injection (DI) của NestJS.
- Sử dụng jest và mock TraineeService để test các method chính:
- getAll: trả về danh sách học viên, handle NotFound và error bất ngờ.
- getById: trả về học viên theo ID, handle NotFound và error bất ngờ.
- create: tạo học viên mới, handle email tồn tại và error bất ngờ.
- update: cập nhật học viên, handle body trống, ID không tồn tại và error bất ngờ.
- delete: xóa học viên, handle ID không tồn tại và error bất ngờ.
- Sử dụng fixture và constants để tái sử dụng dữ liệu test và tăng tính maintainable.

**Tất cả các test đều kiểm tra:**
- Kết quả trả về đúng.
- Service được gọi với tham số chính xác.
- Xử lý các lỗi dự kiến và lỗi bất ngờ.
- Hỗ trợ team đảm bảo controller hoạt động đúng logic trước khi tích hợp với database thật.